### PR TITLE
fix(auth): restore reliable admin login session exchange

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -14,6 +14,7 @@ import {
 	useCallback,
 	useContext,
 	useEffect,
+	useRef,
 	useState,
 } from 'react'
 import { auth } from '@/lib/firebaseClient'
@@ -70,12 +71,14 @@ async function exchangeAdminSession(user: User): Promise<AdminSessionState> {
 
 	const data = (await response.json().catch(() => null)) as {
 		error?: string
+		code?: string
 		session?: AdminSessionState
 	} | null
 
 	if (!response.ok || !data?.session) {
+		const codeSuffix = data?.code ? ` [${data.code}]` : ''
 		throw new Error(
-			data?.error ?? 'No se pudo iniciar la sesion de administrador',
+			`${data?.error ?? 'No se pudo iniciar la sesion de administrador'}${codeSuffix}`,
 		)
 	}
 
@@ -88,6 +91,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 	const [role, setRole] = useState<UserRole | null>(null)
 	const [session, setSession] = useState<AdminSessionState | null>(null)
 	const [isSessionExpired, setIsSessionExpired] = useState(false)
+	const isEstablishingSessionRef = useRef(false)
 
 	const isAdmin = role !== null && canAccessAdmin(role) && session !== null
 
@@ -170,6 +174,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 			setUser(firebaseUser)
 
 			if (!firebaseUser) {
+				isEstablishingSessionRef.current = false
 				setRole(null)
 				clearSessionState()
 				setIsLoading(false)
@@ -179,12 +184,19 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 			const userRole = await fetchRoleFromClaims(firebaseUser)
 
 			if (!userRole || !canAccessAdmin(userRole)) {
+				isEstablishingSessionRef.current = false
 				await performClientSignOut()
 				setIsLoading(false)
 				return
 			}
 
 			setRole(userRole)
+
+			if (isEstablishingSessionRef.current) {
+				setIsLoading(false)
+				return
+			}
+
 			await refreshSessionStatus()
 			setIsLoading(false)
 		})
@@ -193,54 +205,58 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 	}, [clearSessionState, performClientSignOut, refreshSessionStatus])
 
 	const signIn = async (email: string, password: string) => {
-		const userCredential = await signInWithEmailAndPassword(
-			auth,
-			email,
-			password,
-		)
-		const userRole = await fetchRoleFromClaims(userCredential.user)
-
-		if (!userRole || !canAccessAdmin(userRole)) {
-			await performClientSignOut()
-			throw new Error('No tienes permisos de administrador')
-		}
-
-		let nextSession: AdminSessionState
+		isEstablishingSessionRef.current = true
 
 		try {
-			nextSession = await exchangeAdminSession(userCredential.user)
+			const userCredential = await signInWithEmailAndPassword(
+				auth,
+				email,
+				password,
+			)
+			const userRole = await fetchRoleFromClaims(userCredential.user)
+
+			if (!userRole || !canAccessAdmin(userRole)) {
+				await performClientSignOut()
+				throw new Error('No tienes permisos de administrador')
+			}
+
+			const nextSession = await exchangeAdminSession(userCredential.user)
+
+			setRole(userRole)
+			setSession(nextSession)
+			setIsSessionExpired(false)
 		} catch (error) {
 			await performClientSignOut()
 			throw error
+		} finally {
+			isEstablishingSessionRef.current = false
 		}
-
-		setRole(userRole)
-		setSession(nextSession)
-		setIsSessionExpired(false)
 	}
 
 	const signInWithGoogle = async () => {
-		const provider = new GoogleAuthProvider()
-		const userCredential = await signInWithPopup(auth, provider)
-		const userRole = await fetchRoleFromClaims(userCredential.user)
-
-		if (!userRole || !canAccessAdmin(userRole)) {
-			await performClientSignOut()
-			throw new Error('No tienes permisos de administrador')
-		}
-
-		let nextSession: AdminSessionState
+		isEstablishingSessionRef.current = true
 
 		try {
-			nextSession = await exchangeAdminSession(userCredential.user)
+			const provider = new GoogleAuthProvider()
+			const userCredential = await signInWithPopup(auth, provider)
+			const userRole = await fetchRoleFromClaims(userCredential.user)
+
+			if (!userRole || !canAccessAdmin(userRole)) {
+				await performClientSignOut()
+				throw new Error('No tienes permisos de administrador')
+			}
+
+			const nextSession = await exchangeAdminSession(userCredential.user)
+
+			setRole(userRole)
+			setSession(nextSession)
+			setIsSessionExpired(false)
 		} catch (error) {
 			await performClientSignOut()
 			throw error
+		} finally {
+			isEstablishingSessionRef.current = false
 		}
-
-		setRole(userRole)
-		setSession(nextSession)
-		setIsSessionExpired(false)
 	}
 
 	const signOut = async () => {

--- a/src/services/adminSessionService.ts
+++ b/src/services/adminSessionService.ts
@@ -8,6 +8,39 @@ import { adminAuth } from '@/lib/firebaseAdmin'
 import type { CustomClaims, UserRole } from '@/types/auth'
 import { canAccessAdmin, getRoleFromClaims } from '@/types/auth'
 
+interface DecodedAdminIdToken {
+	uid: string
+	email?: string | null
+	[key: string]: unknown
+}
+
+type AdminIdTokenVerifier = (
+	idToken: string,
+) => Promise<DecodedAdminIdToken>
+
+function isFirebaseAdminConfigurationError(error: unknown): boolean {
+	if (!(error instanceof Error)) {
+		return false
+	}
+
+	const message = error.message.toLowerCase()
+	const maybeErrorWithCode = error as Error & { code?: string }
+	const code =
+		typeof maybeErrorWithCode.code === 'string'
+			? maybeErrorWithCode.code.toLowerCase()
+			: ''
+
+	return (
+		code.includes('invalid-credential') ||
+		code.includes('invalid-app-options') ||
+		code.includes('no-app') ||
+		message.includes('credential') ||
+		message.includes('service account') ||
+		message.includes('initializeapp') ||
+		message.includes('project id')
+	)
+}
+
 export interface AdminSessionExchangeResult {
 	role: UserRole
 	expiresAt: string
@@ -16,9 +49,11 @@ export interface AdminSessionExchangeResult {
 
 export async function exchangeAdminSessionFromIdToken(
 	idToken: string,
+	verifyIdToken: AdminIdTokenVerifier = (token) =>
+		adminAuth.verifyIdToken(token) as Promise<DecodedAdminIdToken>,
 ): Promise<AdminSessionExchangeResult> {
 	try {
-		const decodedToken = await adminAuth.verifyIdToken(idToken)
+		const decodedToken = await verifyIdToken(idToken)
 		const claims = decodedToken as unknown as CustomClaims
 		const role = getRoleFromClaims(claims)
 
@@ -45,11 +80,48 @@ export async function exchangeAdminSessionFromIdToken(
 			throw error
 		}
 
-		if (error instanceof Error && error.message.includes('expired')) {
-			throw new ApiError('Token expirado. Inicia sesion nuevamente.', 401)
+		if (
+			error instanceof Error &&
+			error.message.includes('ADMIN_JWT_SECRET is required')
+		) {
+			console.error('[AdminSessionService] Missing ADMIN_JWT_SECRET')
+			throw new ApiError(
+				'Configuracion de sesion de administrador incompleta',
+				500,
+				'ADMIN_SESSION_CONFIG_ERROR',
+			)
 		}
 
-		throw new ApiError('No se pudo crear la sesion de administrador', 401)
+		if (isFirebaseAdminConfigurationError(error)) {
+			console.error('[AdminSessionService] Firebase Admin misconfiguration', error)
+			throw new ApiError(
+				'Configuracion de Firebase Admin invalida',
+				500,
+				'FIREBASE_ADMIN_CONFIG_ERROR',
+			)
+		}
+
+		if (error instanceof Error && error.message.includes('expired')) {
+			throw new ApiError('Token expirado. Inicia sesion nuevamente.', 401, 'TOKEN_EXPIRED')
+		}
+
+		if (
+			error instanceof Error &&
+			(error.message.toLowerCase().includes('invalid') ||
+				error.message.toLowerCase().includes('malformed'))
+		) {
+			throw new ApiError(
+				'Token invalido. Inicia sesion nuevamente.',
+				401,
+				'TOKEN_INVALID',
+			)
+		}
+
+		throw new ApiError(
+			'No se pudo crear la sesion de administrador',
+			401,
+			'ADMIN_SESSION_EXCHANGE_FAILED',
+		)
 	}
 }
 

--- a/tests/admin-session-service.test.ts
+++ b/tests/admin-session-service.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'bun:test'
+import { ApiError } from '@/lib/apiHandler'
+import { exchangeAdminSessionFromIdToken } from '@/services/adminSessionService'
+
+describe('admin session exchange error mapping', () => {
+	it('returns explicit 500 when firebase admin is misconfigured', async () => {
+		const fakeVerifier = async () => {
+			throw Object.assign(
+				new Error(
+					'The credential implementation provided to initializeApp() failed to fetch a valid Google OAuth2 access token',
+				),
+				{ code: 'app/invalid-credential' },
+			)
+		}
+
+		try {
+			await exchangeAdminSessionFromIdToken('fake-token', fakeVerifier)
+			expect(true).toBe(false)
+		} catch (error) {
+			expect(error instanceof ApiError).toBe(true)
+			if (!(error instanceof ApiError)) {
+				return
+			}
+
+			expect(error.statusCode).toBe(500)
+			expect(error.code).toBe('FIREBASE_ADMIN_CONFIG_ERROR')
+		}
+	})
+})


### PR DESCRIPTION
## Summary
- Adds robust error mapping in `adminSessionService` so Firebase Admin or admin session misconfiguration errors are returned with explicit codes (`FIREBASE_ADMIN_CONFIG_ERROR`, `ADMIN_SESSION_CONFIG_ERROR`) instead of opaque 401 failures.
- Stabilizes admin login flow in `AuthContext` by preventing auth-state race conditions during session exchange and surfacing backend error codes in UI messages.
- Adds regression coverage for admin session exchange config failures (`tests/admin-session-service.test.ts`).

## Validation
- bun run check:types
- bun test
- bun run check

## Why this fixes production symptom
`POST /api/admin/session` was returning generic 401 when session exchange failed; frontend retried session status and forced sign-out, creating a loop. This patch makes failures deterministic and prevents session refresh from racing while exchange is in progress.