### PR TITLE
feat(seo): wire public SEO rollout gating

### DIFF
--- a/openspec/changes/rollout-flags-and-observability-hardening/specs/public-seo/spec.md
+++ b/openspec/changes/rollout-flags-and-observability-hardening/specs/public-seo/spec.md
@@ -1,0 +1,22 @@
+# Public SEO Specification
+
+## Purpose
+Defines the visibility of the application to search engines gated by the `PUBLIC_SEO_ENABLED` flag.
+
+## Requirements
+
+### Requirement: SEO Enabled
+The system MUST output permissive crawling directives when SEO is enabled.
+
+#### Scenario: Search engines allowed
+- GIVEN `PUBLIC_SEO_ENABLED` is true
+- WHEN a bot requests `robots.txt` or metadata
+- THEN the system returns `Allow: /` and indexable `<meta>` tags
+
+### Requirement: SEO Disabled
+The system MUST actively prevent indexing when SEO is disabled.
+
+#### Scenario: Search engines blocked
+- GIVEN `PUBLIC_SEO_ENABLED` is false
+- WHEN a bot requests `robots.txt` or metadata
+- THEN the system returns `Disallow: /` and `noindex, nofollow` metadata

--- a/src/app/(public)/layout.tsx
+++ b/src/app/(public)/layout.tsx
@@ -1,8 +1,10 @@
 import type { Metadata } from 'next'
-import { INDEXABLE_ROBOTS } from '@/lib/seo'
+import { buildPublicRobotsMetadata } from '@/lib/seo'
 
-export const metadata: Metadata = {
-	robots: INDEXABLE_ROBOTS,
+export function generateMetadata(): Metadata {
+	return {
+		robots: buildPublicRobotsMetadata(),
+	}
 }
 
 export default function PublicLayout({

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,21 +1,6 @@
 import type { MetadataRoute } from 'next'
-import { APP_URL, PUBLIC_PATHS } from '@/lib/seo'
+import { buildPublicRobotsManifest } from '@/lib/seo'
 
 export default function robots(): MetadataRoute.Robots {
-	return {
-		rules: {
-			userAgent: '*',
-			allow: [...PUBLIC_PATHS],
-			disallow: [
-				'/admin/',
-				'/ingreso/',
-				'/otp/',
-				'/registro/',
-				'/consentimiento/',
-				'/exito/',
-			],
-		},
-		sitemap: `${APP_URL}/sitemap.xml`,
-		host: APP_URL,
-	}
+	return buildPublicRobotsManifest()
 }

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,13 +1,6 @@
 import type { MetadataRoute } from 'next'
-import { createCanonicalUrl, PUBLIC_PATHS } from '@/lib/seo'
+import { buildPublicSitemap } from '@/lib/seo'
 
 export default function sitemap(): MetadataRoute.Sitemap {
-	const now = new Date()
-
-	return PUBLIC_PATHS.map((pathname) => ({
-		url: createCanonicalUrl(pathname),
-		lastModified: now,
-		changeFrequency: 'monthly',
-		priority: 0.7,
-	}))
+	return buildPublicSitemap()
 }

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -1,4 +1,5 @@
-import type { Metadata } from 'next'
+import type { Metadata, MetadataRoute } from 'next'
+import { evaluateHardeningFlag, HARDENING_FLAG } from '@/lib/hardeningPolicy'
 
 export const APP_NAME = 'Jumping Park'
 export const APP_DESCRIPTION =
@@ -32,4 +33,70 @@ export const INDEXABLE_ROBOTS: NonNullable<Metadata['robots']> = {
 
 export function createCanonicalUrl(pathname = '/'): string {
 	return new URL(pathname, APP_URL).toString()
+}
+
+export function buildPublicRobotsMetadata(): NonNullable<Metadata['robots']> {
+	const policy = evaluateHardeningFlag({
+		featureName: HARDENING_FLAG.PUBLIC_SEO,
+		source: 'public-metadata',
+		route: '/(public)',
+	})
+
+	return policy.enabled ? INDEXABLE_ROBOTS : NON_INDEXABLE_ROBOTS
+}
+
+export function buildPublicRobotsManifest(): MetadataRoute.Robots {
+	const policy = evaluateHardeningFlag({
+		featureName: HARDENING_FLAG.PUBLIC_SEO,
+		source: 'robots',
+		route: '/robots.txt',
+	})
+
+	if (!policy.enabled) {
+		return {
+			rules: {
+				userAgent: '*',
+				disallow: ['/'],
+			},
+			host: APP_URL,
+		}
+	}
+
+	return {
+		rules: {
+			userAgent: '*',
+			allow: [...PUBLIC_PATHS],
+			disallow: [
+				'/admin/',
+				'/ingreso/',
+				'/otp/',
+				'/registro/',
+				'/consentimiento/',
+				'/exito/',
+			],
+		},
+		sitemap: `${APP_URL}/sitemap.xml`,
+		host: APP_URL,
+	}
+}
+
+export function buildPublicSitemap(): MetadataRoute.Sitemap {
+	const policy = evaluateHardeningFlag({
+		featureName: HARDENING_FLAG.PUBLIC_SEO,
+		source: 'sitemap',
+		route: '/sitemap.xml',
+	})
+
+	if (!policy.enabled) {
+		return []
+	}
+
+	const now = new Date()
+
+	return PUBLIC_PATHS.map((pathname) => ({
+		url: createCanonicalUrl(pathname),
+		lastModified: now,
+		changeFrequency: 'monthly',
+		priority: 0.7,
+	}))
 }

--- a/tests/seo-public.test.ts
+++ b/tests/seo-public.test.ts
@@ -4,36 +4,89 @@ import { NextRequest } from 'next/server'
 const { proxy } = await import('@/proxy')
 const { default: robots } = await import('@/app/robots')
 const { default: sitemap } = await import('@/app/sitemap')
+const { generateMetadata } = await import('@/app/(public)/layout')
+
+async function withEnv<T>(
+	key: string,
+	value: string | undefined,
+	callback: () => Promise<T> | T,
+): Promise<T> {
+	const previousValue = process.env[key]
+
+	if (value === undefined) {
+		delete process.env[key]
+	} else {
+		process.env[key] = value
+	}
+
+	try {
+		return await callback()
+	} finally {
+		if (previousValue === undefined) {
+			delete process.env[key]
+		} else {
+			process.env[key] = previousValue
+		}
+	}
+}
 
 describe('public seo boundary', () => {
 	it('applies noindex header to kiosk root without leaking to public pages', async () => {
-		const kioskResponse = await proxy(new NextRequest('https://example.com/'))
-		const publicResponse = await proxy(
-			new NextRequest('https://example.com/consentimiento-digital'),
-		)
+		await withEnv('PUBLIC_SEO_ENABLED', 'true', async () => {
+			const kioskResponse = await proxy(new NextRequest('https://example.com/'))
+			const publicResponse = await proxy(
+				new NextRequest('https://example.com/consentimiento-digital'),
+			)
 
-		expect(kioskResponse.headers.get('X-Robots-Tag')).toBe('noindex, nofollow')
-		expect(publicResponse.headers.get('X-Robots-Tag')).toBe(null)
+			expect(kioskResponse.headers.get('X-Robots-Tag')).toBe('noindex, nofollow')
+			expect(publicResponse.headers.get('X-Robots-Tag')).toBe(null)
+		})
 	})
 
-	it('publishes robots rules only for public urls', () => {
-		const manifest = robots()
-		const rules = Array.isArray(manifest.rules)
-			? manifest.rules[0]
-			: manifest.rules
+	it('publishes robots, sitemap, and metadata when public SEO is enabled', async () => {
+		await withEnv('PUBLIC_SEO_ENABLED', 'true', async () => {
+			const manifest = robots()
+			const rules = Array.isArray(manifest.rules)
+				? manifest.rules[0]
+				: manifest.rules
+			const entries = sitemap()
+			const metadata = generateMetadata()
+			const robotsMetadata = metadata.robots as {
+				index?: boolean
+				follow?: boolean
+			}
 
-		expect(rules?.allow).toContain('/consentimiento-digital')
-		expect(rules?.disallow).toContain('/admin/')
-		expect(rules?.disallow).toContain('/ingreso/')
-		expect(manifest.sitemap).toBe('https://www.jumpingpark.lat/sitemap.xml')
+			expect(rules?.allow).toContain('/consentimiento-digital')
+			expect(rules?.disallow).toContain('/admin/')
+			expect(rules?.disallow).toContain('/ingreso/')
+			expect(manifest.sitemap).toBe('https://www.jumpingpark.lat/sitemap.xml')
+			expect(entries.length).toBe(1)
+			expect(entries[0]?.url).toBe(
+				'https://www.jumpingpark.lat/consentimiento-digital',
+			)
+			expect(robotsMetadata.index).toBe(true)
+			expect(robotsMetadata.follow).toBe(true)
+		})
 	})
 
-	it('includes only public urls in sitemap', () => {
-		const entries = sitemap()
+	it('blocks robots, hides sitemap, and returns noindex metadata when SEO is disabled', async () => {
+		await withEnv('PUBLIC_SEO_ENABLED', 'false', async () => {
+			const manifest = robots()
+			const rules = Array.isArray(manifest.rules)
+				? manifest.rules[0]
+				: manifest.rules
+			const entries = sitemap()
+			const metadata = generateMetadata()
+			const robotsMetadata = metadata.robots as {
+				index?: boolean
+				follow?: boolean
+			}
 
-		expect(entries.length).toBe(1)
-		expect(entries[0]?.url).toBe(
-			'https://www.jumpingpark.lat/consentimiento-digital',
-		)
+			expect(rules?.disallow).toContain('/')
+			expect(manifest.sitemap).toBe(undefined)
+			expect(entries.length).toBe(0)
+			expect(robotsMetadata.index).toBe(false)
+			expect(robotsMetadata.follow).toBe(false)
+		})
 	})
 })


### PR DESCRIPTION
Closes #9

## Summary
- wire PUBLIC_SEO_ENABLED through shared hardening policy in robots, sitemap, and public metadata
- keep SEO behavior server-side and deterministic for enabled vs disabled states
- add OpenSpec public-seo spec and targeted tests for crawler and metadata outputs

## Testing
- bun run check:types
- bun test tests/seo-public.test.ts