### PR TITLE
feat(seo): wire public SEO rollout gating

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,6 +22,12 @@ ADMIN_JWT_SECRET=replace-with-a-random-secret-min-32-chars
 ADMIN_SESSION_MODE=dual
 ADMIN_IDLE_TIMEOUT_MINUTES=30
 OTP_LOCKOUT_MINUTES=15
+OTP_HARDENING_ENABLED=true
+EXPORT_BOUNDS_ENFORCED=true
+PUBLIC_SEO_ENABLED=false
+
+# Flag changes require a local server restart.
+# On Vercel/preview/production, update env vars and redeploy.
 
 # Optional local/setup flags
 ALLOW_ADMIN_SETUP=false

--- a/README.md
+++ b/README.md
@@ -141,6 +141,9 @@ ADMIN_JWT_SECRET=una-clave-secreta-larga-y-aleatoria-min-32-chars
 ADMIN_SESSION_MODE=dual
 ADMIN_IDLE_TIMEOUT_MINUTES=30
 OTP_LOCKOUT_MINUTES=15
+OTP_HARDENING_ENABLED=true
+EXPORT_BOUNDS_ENFORCED=true
+PUBLIC_SEO_ENABLED=false
 ALLOW_ADMIN_SETUP=false
 ADMIN_SECRET_KEY=
 FIREBASE_SERVICE_ACCOUNT_KEY=
@@ -157,6 +160,15 @@ ANALYZE=false
 | `RESEND_API_KEY` | API Key de Resend. Comienza con `re_` | [resend.com/api-keys](https://resend.com/api-keys) |
 | `ADMIN_JWT_SECRET` | Secreto para firmar tokens JWT | Generar string aleatorio de 32+ caracteres |
 | `ADMIN_SESSION_MODE` | Mantener `dual` durante el rollout de sesión cookie-first | Configuración local/Vercel |
+| `OTP_HARDENING_ENABLED` | Activa o desactiva el enforcement estricto de OTP; dejar `true` salvo rollback controlado | `.env.local` / Vercel |
+| `EXPORT_BOUNDS_ENFORCED` | Mantiene el rechazo de exports sin rango o mayores a 30 días | `.env.local` / Vercel |
+| `PUBLIC_SEO_ENABLED` | Expone `robots.txt`, `sitemap.xml` y metadata indexable para la superficie pública | `.env.local` / Vercel |
+
+### Semántica de rollout de flags
+
+- Local/dev: cambiar `OTP_HARDENING_ENABLED`, `EXPORT_BOUNDS_ENFORCED` o `PUBLIC_SEO_ENABLED` requiere reiniciar `bun dev`.
+- Preview/producción en Vercel: actualizar variables de entorno requiere un nuevo deploy para que rutas y metadata server-side tomen el cambio.
+- Defaults recomendados: `OTP_HARDENING_ENABLED=true`, `EXPORT_BOUNDS_ENFORCED=true`, `PUBLIC_SEO_ENABLED=false` hasta completar humo SEO.
 
 ---
 

--- a/docs/runbooks/production-hardening.md
+++ b/docs/runbooks/production-hardening.md
@@ -2,6 +2,19 @@
 
 Use this smoke pack after each hardening PR or before production rollout. All examples assume the app is running at `http://localhost:3000`; replace the origin as needed for preview or production.
 
+## 0. Rollout flags and deploy semantics
+
+Set the hardening flags explicitly in every environment before smoke testing:
+
+- `OTP_HARDENING_ENABLED=true` keeps OTP throttling and lockout enforcement on.
+- `EXPORT_BOUNDS_ENFORCED=true` keeps bounded export rejection on.
+- `PUBLIC_SEO_ENABLED=false` blocks public indexing until the SEO batch is approved.
+
+Operational rule:
+
+- Local/dev flag flips require restarting `bun dev`.
+- Preview/production flag flips on Vercel require a fresh deployment before `robots.txt`, `sitemap.xml`, OTP routes, or export routes reflect the new value.
+
 ## 1. Admin session smoke
 
 Goal: confirm the cookie-first admin session works, and `ADMIN_SESSION_MODE=dual` still accepts the Bearer baseline during rollout.
@@ -76,6 +89,7 @@ Expected:
 - attempts 1-3: `HTTP/1.1 200 OK`
 - attempt 4: `HTTP/1.1 429 Too Many Requests`
 - headers include `Retry-After: <seconds>`
+- headers include `X-Hardening-Feature: otp-hardening` and `X-Hardening-Status: enabled`
 - body includes `{"code":"OTP_RATE_LIMITED","retryAfter":<seconds>}`
 
 ### 2.2 Validation lock after 5 bad codes
@@ -92,6 +106,7 @@ Expected:
 - attempts 1-4: `HTTP/1.1 404 Not Found`
 - attempt 5: `HTTP/1.1 429 Too Many Requests`
 - headers include `Retry-After: <seconds>`
+- headers include `X-Hardening-Feature: otp-hardening` and `X-Hardening-Status: enabled`
 - body includes `{"code":"OTP_LOCKED","error":"Session locked","retryAfter":<seconds>}`
 
 ## 3. Export bounds behavior
@@ -130,6 +145,8 @@ curl -i "http://localhost:3000/api/admin/export/users?field=createdAt&from=2026-
 Expected:
 - `HTTP/1.1 200 OK`
 - CSV body downloads normally
+- headers include `X-Hardening-Feature: export-bounds`
+- headers include `X-Hardening-Status: enabled`
 - headers include:
   - `X-Export-Range-Field: createdAt`
   - `X-Export-Range-From: 2026-01-01`
@@ -137,9 +154,32 @@ Expected:
   - `X-Export-Max-Days: 30`
   - `X-Export-Rejected: false`
 
+### 3.4 Fallback smoke when export bounds are intentionally disabled
+
+Precondition: `EXPORT_BOUNDS_ENFORCED=false` and the app has been restarted or redeployed.
+
+```bash
+curl -i "http://localhost:3000/api/admin/export/users?from=2026-01-01&to=2026-12-31" \
+  -H "Cookie: jp_admin_session=<cookie-from-login>"
+```
+
+Expected:
+- `HTTP/1.1 200 OK`
+- headers include `X-Hardening-Status: disabled`
+- headers include `X-Export-Row-Cap: 5000`
+- rollback by restoring `EXPORT_BOUNDS_ENFORCED=true` and redeploying
+
 ## 4. Robots and sitemap checks
 
 Goal: confirm only the public SEO surface is discoverable.
+
+### 4.0 Pre-flight for SEO rollout
+
+Before enabling SEO in preview or production:
+
+1. Set `PUBLIC_SEO_ENABLED=true`.
+2. Redeploy.
+3. Run the checks below against the deployed URL, not a stale build.
 
 ### 4.1 `robots.txt`
 
@@ -183,6 +223,21 @@ Expected public page (`/consentimiento-digital`):
 Expected kiosk root (`/`):
 - header `X-Robots-Tag: noindex, nofollow`
 - HTML includes `<meta name="robots" content="noindex, nofollow">`
+
+### 4.4 Rollback smoke for SEO disable
+
+Precondition: `PUBLIC_SEO_ENABLED=false` after redeploy.
+
+```bash
+curl -i http://localhost:3000/robots.txt
+curl -i http://localhost:3000/sitemap.xml
+curl -s http://localhost:3000/consentimiento-digital
+```
+
+Expected:
+- `robots.txt` includes `Disallow: /`
+- `sitemap.xml` returns no public entries
+- `/consentimiento-digital` renders `noindex, nofollow` metadata
 
 ## Rollback notes
 

--- a/openspec/changes/rollout-flags-and-observability-hardening/design.md
+++ b/openspec/changes/rollout-flags-and-observability-hardening/design.md
@@ -1,0 +1,97 @@
+# Design: Rollout Flags and Observability Hardening
+
+## Technical Approach
+
+Add a small server-only policy resolver, `src/lib/hardeningPolicy.ts`, as the single source of truth for rollout flags and hardening telemetry. OTP routes/services, admin export handlers, and SEO metadata/routes read that resolver instead of `process.env` directly. The change stays incremental: first pure policy + docs, then OTP/export wiring, then SEO wiring.
+
+## Architecture Decisions
+
+| Decision | Options | Choice / Rationale |
+|---|---|---|
+| Policy source | Inline `process.env`; shared module | Use a shared module with typed resolvers. This matches the existing service-layer pattern, keeps route handlers thin, and prevents drift between OTP, export, and SEO surfaces. |
+| Telemetry transport | New vendor SDK; ad-hoc `console.*`; structured server logs + headers | Use structured `console.info`/`console.warn` plus additive response headers. This gives deterministic observability without new infra and supports curl/smoke verification. |
+| OTP fallback | Leave strict logic always on; re-enable permissive branch | Add explicit strict/permissive execution modes in the request/validate orchestration helpers, without changing session creation or admin auth. This satisfies spec rollback while keeping the diff local to OTP codepaths. |
+
+## Data Flow
+
+```text
+request -> route.ts / robots.ts / sitemap.ts / metadata
+        -> hardeningPolicy.resolve()
+        -> { flags, telemetry helpers, response headers }
+
+OTP request/validate -> authService strict|permissive branch
+                     -> emit hardening event
+                     -> NextResponse headers
+
+Admin export -> resolve export policy -> bounded|permissive range
+             -> build CSV -> emit hardening event + export headers
+
+SEO route/metadata -> resolve SEO policy -> allowlist|block-all robots
+                   -> emit hardening event
+```
+
+## File Changes
+
+| File | Action | Description |
+|---|---|---|
+| `src/lib/hardeningPolicy.ts` | Create | Typed flag parsing, secure defaults, telemetry/header helpers. |
+| `src/services/authService.ts` | Modify | Add strict/permissive OTP orchestration and event emission. |
+| `src/app/api/otp/route.ts` | Modify | Attach policy headers from OTP request flow. |
+| `src/app/api/otp/validate/route.ts` | Modify | Attach policy headers from OTP validate flow. |
+| `src/services/exportRangeService.ts` | Modify | Introduce policy-aware bounded vs permissive range resolution. |
+| `src/app/api/admin/export/users/route.ts` | Modify | Use policy-aware export resolution and telemetry headers. |
+| `src/app/api/admin/export/consents/route.ts` | Modify | Same as users export. |
+| `src/lib/seo.ts` | Modify | Centralize SEO robots metadata builders driven by policy. |
+| `src/app/robots.ts` | Modify | Return allowlist or block-all rules from shared SEO helpers. |
+| `src/app/sitemap.ts` | Modify | Return public entries only when SEO is enabled. |
+| `src/app/(public)/layout.tsx` | Modify | Switch to policy-driven robots metadata via `generateMetadata`. |
+| `tests/auth-hardening.test.ts` | Modify | Cover flag-on/off OTP behavior and emitted headers/events. |
+| `tests/operational-hardening.test.ts` | Modify | Cover policy defaults and export bypass/enforced branches. |
+| `tests/seo-public.test.ts` | Modify | Cover SEO enabled/disabled across robots, sitemap, metadata. |
+| `.env.example`, `README.md`, `docs/runbooks/production-hardening.md` | Modify | Document flags and rollout/rollback procedure per environment. |
+
+## Interfaces / Contracts
+
+```ts
+const HARDENING_FLAG = {
+  OTP_HARDENING: 'otp-hardening',
+  EXPORT_BOUNDS: 'export-bounds',
+  PUBLIC_SEO: 'public-seo',
+} as const
+
+interface HardeningPolicy {
+  otpHardeningEnabled: boolean
+  exportBoundsEnabled: boolean
+  publicSeoEnabled: boolean
+}
+
+interface HardeningEvent {
+  eventName: 'hardening.policy.evaluated'
+  featureName: (typeof HARDENING_FLAG)[keyof typeof HARDENING_FLAG]
+  status: 'enabled' | 'disabled' | 'defaulted'
+  source: 'otp-request' | 'otp-validate' | 'admin-export-users' | 'admin-export-consents' | 'robots' | 'sitemap' | 'public-metadata'
+  envKey: string
+  fallbackApplied: boolean
+  requestId?: string
+  route?: string
+  details?: Record<string, string | number | boolean>
+}
+```
+
+Headers are additive, not authoritative: `X-Hardening-Policy`, `X-Hardening-Feature`, `X-Hardening-Status`. Export routes keep existing `X-Export-*` headers.
+
+## Testing Strategy
+
+| Layer | What to Test | Approach |
+|---|---|---|
+| Unit | Env parsing, malformed fallback, header/event builders, SEO metadata builders | Bun tests with module re-import after env mutation. |
+| Service | OTP strict vs permissive request/validate flow; export range enforced vs bypassed | Extend current dependency-injected service tests; assert no extra client churn. |
+| Route/integration | OTP/export headers and SEO route outputs | Existing Bun route-style tests for `robots`, `sitemap`, and route handlers. |
+
+## Migration / Rollout
+
+No data migration required. Rollout order: (1) ship policy module with all flags defaulting secure-on, (2) enable OTP/export wiring in dev, then preview, (3) enable SEO wiring after smoke checks. In local/dev, flag flips require server restart. In preview/prod on Vercel, env changes require a new deployment to affect bundled route handlers and metadata. Keep `ADMIN_SESSION_MODE` untouched; the policy module may read it later, but this change does not alter admin-session behavior.
+
+## Open Questions
+
+- [ ] When `EXPORT_BOUNDS_ENFORCED=false`, keep the existing 5000-row Firestore query limit as a safety cap while removing date-window rejection.

--- a/openspec/changes/rollout-flags-and-observability-hardening/exploration.md
+++ b/openspec/changes/rollout-flags-and-observability-hardening/exploration.md
@@ -1,0 +1,42 @@
+## Exploration: rollout-flags-and-observability-hardening
+
+### Current State
+The hardening change is mostly implemented, but the rollout-control decision from the approved design is incomplete. `ADMIN_SESSION_MODE` exists in `src/lib/adminAuth.ts:8`, while the other three planned gates (`OTP_HARDENING_ENABLED`, `EXPORT_BOUNDS_ENFORCED`, `PUBLIC_SEO_ENABLED`) are absent, so OTP hardening, bounded exports, and public SEO are always-on behaviors instead of canary-able features. The runtime already has the hardened code paths in `src/services/authService.ts:517`, `src/services/exportRangeService.ts:65`, `src/app/api/admin/export/users/route.ts:21`, `src/app/api/admin/export/consents/route.ts:24`, `src/app/robots.ts:4`, `src/app/sitemap.ts:4`, and `src/proxy.ts:48`, but those paths are not mediated by a shared rollout policy. Observability is also fragmented: `docs/runbooks/production-hardening.md:1` documents smoke checks, tests cover OTP/export/SEO behavior, and `src/services/authService.ts:83` masks some OTP identifiers, but there is no centralized hardening telemetry or flag-state reporting, and other services such as `src/services/consentService.ts:252` still rely on raw console logging.
+
+### Affected Areas
+- `openspec/changes/production-hardening-professionalization/design.md` — source decision that promised dual rollout flags beyond admin session mode.
+- `openspec/changes/production-hardening-professionalization/verify-report.md` — current verification evidence calling out the missing flags as an explicit warning.
+- `src/lib/adminAuth.ts` — existing pattern for env-driven rollout via `ADMIN_SESSION_MODE`; likely model for a shared policy layer.
+- `src/services/authService.ts` — OTP request/validate hardening and masked logging live here; needs flag gating and observability hooks.
+- `src/services/exportRangeService.ts` — export-bound enforcement currently hard-coded and always enforced.
+- `src/app/api/admin/export/users/route.ts` — users export entry point where fallback vs enforced behavior would branch.
+- `src/app/api/admin/export/consents/route.ts` — consents export entry point with the same rollout concern.
+- `src/lib/seo.ts` — likely home for public-SEO enablement helpers or route allowlists.
+- `src/app/robots.ts` — public crawler surface should be suppressible when `PUBLIC_SEO_ENABLED` is off.
+- `src/app/sitemap.ts` — same public-surface gating requirement as robots.
+- `src/app/layout.tsx` and `src/app/(public)/layout.tsx` — metadata boundary already exists, but public indexability needs a single flag-driven source of truth.
+- `.env.example` and `README.md` — env contract and rollout/runbook docs must expose the three missing flags and operator expectations.
+- `tests/auth-hardening.test.ts`, `tests/operational-hardening.test.ts`, `tests/seo-public.test.ts` — current safety net; should expand to prove flag-off, flag-on, and telemetry behavior.
+
+### Approaches
+1. **Inline route-level flags** — add direct `process.env.*` checks inside OTP, export, and SEO entry points.
+   - Pros: small diff, fast to ship, low conceptual overhead.
+   - Cons: flag semantics drift easily, tests duplicate setup, observability becomes scattered, rollback behavior can diverge across entry points.
+   - Effort: Low
+
+2. **Central hardening policy module** — introduce a typed runtime policy/helper that resolves rollout flags and exposes shared observability metadata for OTP, export, and SEO flows.
+   - Pros: single source of truth, stricter typing, easier App Router-safe consumption, cleaner tests, one place to add operator-visible telemetry and docs.
+   - Cons: touches multiple areas at once, requires defining fallback behavior per surface before implementation.
+   - Effort: Medium
+
+### Recommendation
+Recommend **Central hardening policy module**. The repo already proved one env-controlled rollout path with `ADMIN_SESSION_MODE`; the missing work is not just adding booleans, it is restoring the design promise of safe canary/rollback and making those states observable. A typed policy layer keeps `OTP_HARDENING_ENABLED`, `EXPORT_BOUNDS_ENFORCED`, and `PUBLIC_SEO_ENABLED` consistent, lets OTP/export/SEO endpoints emit deterministic headers or structured logs about active policy, and supports small PRs: first policy + docs, then OTP/export wiring, then SEO wiring + smoke/test coverage.
+
+### Risks
+- OTP rollback semantics are not yet defined: if `OTP_HARDENING_ENABLED=false`, the team must decide whether to preserve current hardened behavior, re-enable legacy mixed-session paths, or expose only softer response contracts.
+- Export rollback can weaken security/cost posture if `EXPORT_BOUNDS_ENFORCED=false` simply reopens unbounded downloads without audit markers.
+- SEO rollback affects discoverability and caching; disabling `PUBLIC_SEO_ENABLED` must suppress `robots.txt`, `sitemap.xml`, and indexable metadata coherently to avoid mixed signals.
+- Observability scope can sprawl if this change tries to solve all logging cleanup instead of hardening-specific telemetry first.
+
+### Ready for Proposal
+Yes — proceed to `sdd-propose` for a follow-up change scoped to: (1) typed rollout-policy contract + env/docs updates, (2) OTP/export flag wiring with deterministic observability, and (3) public SEO gating plus smoke/test updates. Keep implementation incremental and PR-sized rather than reopening the whole hardening program.

--- a/openspec/changes/rollout-flags-and-observability-hardening/proposal.md
+++ b/openspec/changes/rollout-flags-and-observability-hardening/proposal.md
@@ -1,0 +1,70 @@
+# Proposal: Rollout Flags and Observability Hardening
+
+## Intent
+Implement missing rollout flags (`OTP_HARDENING_ENABLED`, `EXPORT_BOUNDS_ENFORCED`, `PUBLIC_SEO_ENABLED`) and shared observability logging to restore the safe canary/rollback promise of the production hardening design.
+
+## Scope
+
+### In Scope
+- Create a central typed hardening policy module for rollout flags.
+- Wire `OTP_HARDENING_ENABLED` to OTP request/validate endpoints.
+- Wire `EXPORT_BOUNDS_ENFORCED` to export endpoints.
+- Wire `PUBLIC_SEO_ENABLED` to SEO surfaces (`robots.txt`, `sitemap.xml`, layouts).
+- Add deterministic observability metadata (headers/logs) for active policies.
+- Update `.env.example`, `README.md`, and runbook docs with flag expectations.
+
+### Out of Scope
+- Complete refactoring of all application logging.
+- Changing the underlying hardening behavior (only gating it).
+- Changes to existing `ADMIN_SESSION_MODE` logic, other than potentially unifying it into the new policy.
+
+## Capabilities
+
+### New Capabilities
+- `rollout-policy`: Central typed runtime policy for resolving and observing feature flags.
+- `hardened-otp`: Gated by `OTP_HARDENING_ENABLED` flag.
+- `bounded-export`: Gated by `EXPORT_BOUNDS_ENFORCED` flag.
+- `public-seo`: Gated by `PUBLIC_SEO_ENABLED` flag.
+
+### Modified Capabilities
+- None
+
+## Approach
+Introduce a central hardening policy module (`src/lib/hardeningPolicy.ts`) that reads environment variables and exposes typed feature flags and observability helpers. Update OTP, export, and SEO entry points to consult this policy module before enforcing hardened behaviors. If a flag is disabled, the system will gracefully fall back to legacy/unbounded behaviors while logging the fallback state.
+
+## PR Slicing Strategy
+1. **Core Policy & Docs**: Introduce `src/lib/hardeningPolicy.ts`, observability helpers, and update `.env.example`/docs. (Focus: Pure typing, no behavior change).
+2. **OTP & Export Wiring**: Wire `OTP_HARDENING_ENABLED` and `EXPORT_BOUNDS_ENFORCED` flags to API routes and services with deterministic logs. (Focus: Rollback path testing).
+3. **SEO Wiring**: Wire `PUBLIC_SEO_ENABLED` to `robots.txt`, `sitemap.xml`, and metadata. (Focus: Public surface gating).
+
+## Affected Areas
+
+| Area | Impact | Description |
+|------|--------|-------------|
+| `src/lib/hardeningPolicy.ts` | New | Central typed policy module |
+| `src/services/authService.ts` | Modified | Wire OTP hardening flag |
+| `src/app/api/admin/export/users/route.ts` | Modified | Wire export bounds flag |
+| `src/app/api/admin/export/consents/route.ts`| Modified | Wire export bounds flag |
+| `src/app/robots.ts` | Modified | Wire SEO flag |
+| `src/app/sitemap.ts` | Modified | Wire SEO flag |
+| `src/app/layout.tsx` | Modified | Wire SEO metadata flag |
+| `.env.example` / Docs | Modified | Add new flags and operational expectations |
+
+## Risks
+
+| Risk | Likelihood | Mitigation |
+|------|------------|------------|
+| Unintended exposure of legacy paths | Medium | Strict default-on for flags if env vars are missing; comprehensive tests for flag-off states. |
+| Inconsistent SEO indexing | Low | Ensure `robots.txt`, `sitemap.xml`, and layout metadata all strictly read from the same policy flag. |
+
+## Rollback Plan
+Operators can immediately disable a specific feature by toggling its environment variable (`OTP_HARDENING_ENABLED=false`, `EXPORT_BOUNDS_ENFORCED=false`, `PUBLIC_SEO_ENABLED=false`) and restarting the application, falling back to legacy behavior without a code deployment.
+
+## Dependencies
+- None
+
+## Success Criteria
+- [ ] Central policy module exists and is fully typed.
+- [ ] OTP, export, and SEO behaviors can be toggled via environment variables without code changes.
+- [ ] Disabling a flag successfully reverts the system to pre-hardening behavior.
+- [ ] Active policy state is logged/observable during critical operations.

--- a/openspec/changes/rollout-flags-and-observability-hardening/specs/bounded-export/spec.md
+++ b/openspec/changes/rollout-flags-and-observability-hardening/specs/bounded-export/spec.md
@@ -1,0 +1,28 @@
+# Bounded Export Specification
+
+## Purpose
+Defines the behavior of admin data export operations when gated by the `EXPORT_BOUNDS_ENFORCED` flag.
+
+## Requirements
+
+### Requirement: Export Bounds Enforced
+The system MUST enforce strict date range and size bounds on exports when enabled.
+
+#### Scenario: Bounds check passes
+- GIVEN `EXPORT_BOUNDS_ENFORCED` is true
+- WHEN an admin requests a 30-day data export
+- THEN the system fulfills the request
+
+#### Scenario: Bounds check fails
+- GIVEN `EXPORT_BOUNDS_ENFORCED` is true
+- WHEN an admin requests a 1-year data export
+- THEN the system rejects the request with a 400 Bad Request
+
+### Requirement: Export Bounds Disabled (Fallback)
+The system MUST allow unbounded exports when the flag is disabled.
+
+#### Scenario: Unbounded export allowed
+- GIVEN `EXPORT_BOUNDS_ENFORCED` is false
+- WHEN an admin requests a 1-year data export
+- THEN the system processes the large export request
+- AND logs an observability marker indicating bounds were bypassed

--- a/openspec/changes/rollout-flags-and-observability-hardening/specs/hardened-otp/spec.md
+++ b/openspec/changes/rollout-flags-and-observability-hardening/specs/hardened-otp/spec.md
@@ -1,0 +1,24 @@
+# Hardened OTP Specification
+
+## Purpose
+Defines the behavior of OTP generation and validation when gated by the `OTP_HARDENING_ENABLED` flag.
+
+## Requirements
+
+### Requirement: Hardening Enabled
+The system MUST enforce OTP lockout and retry limits when the flag is enabled.
+
+#### Scenario: OTP limits enforced
+- GIVEN `OTP_HARDENING_ENABLED` is true
+- WHEN a user exceeds max OTP attempts
+- THEN the system rejects the request with a 429 Too Many Requests
+- AND records the lockout state
+
+### Requirement: Hardening Disabled (Fallback)
+The system MUST bypass OTP strict limits when the flag is disabled to allow unconstrained testing or fallback.
+
+#### Scenario: OTP limits bypassed
+- GIVEN `OTP_HARDENING_ENABLED` is false
+- WHEN a user makes excessive OTP requests
+- THEN the system processes the requests without applying lockout mechanisms
+- AND logs an observability marker indicating the hardening check was bypassed

--- a/openspec/changes/rollout-flags-and-observability-hardening/specs/public-seo/spec.md
+++ b/openspec/changes/rollout-flags-and-observability-hardening/specs/public-seo/spec.md
@@ -1,0 +1,22 @@
+# Public SEO Specification
+
+## Purpose
+Defines the visibility of the application to search engines gated by the `PUBLIC_SEO_ENABLED` flag.
+
+## Requirements
+
+### Requirement: SEO Enabled
+The system MUST output permissive crawling directives when SEO is enabled.
+
+#### Scenario: Search engines allowed
+- GIVEN `PUBLIC_SEO_ENABLED` is true
+- WHEN a bot requests `robots.txt` or metadata
+- THEN the system returns `Allow: /` and indexable `<meta>` tags
+
+### Requirement: SEO Disabled
+The system MUST actively prevent indexing when SEO is disabled.
+
+#### Scenario: Search engines blocked
+- GIVEN `PUBLIC_SEO_ENABLED` is false
+- WHEN a bot requests `robots.txt` or metadata
+- THEN the system returns `Disallow: /` and `noindex, nofollow` metadata

--- a/openspec/changes/rollout-flags-and-observability-hardening/specs/rollout-policy/spec.md
+++ b/openspec/changes/rollout-flags-and-observability-hardening/specs/rollout-policy/spec.md
@@ -1,0 +1,28 @@
+# Rollout Policy Specification
+
+## Purpose
+Defines the central typed runtime policy for resolving and observing feature flags related to hardening.
+
+## Requirements
+
+### Requirement: Flag Resolution
+The system MUST resolve feature flags from environment variables with a safe fallback.
+
+#### Scenario: Flag enabled explicitly
+- GIVEN `OTP_HARDENING_ENABLED` is set to "true"
+- WHEN the policy module is queried for OTP hardening
+- THEN it returns true
+
+#### Scenario: Flag missing or malformed
+- GIVEN an environment variable is omitted or invalid
+- WHEN the policy module is queried
+- THEN it defaults to true (secure by default)
+- AND logs a warning about the fallback
+
+### Requirement: Observability Logging
+The system MUST provide deterministic observability markers for enabled/disabled mode decisions.
+
+#### Scenario: Operation uses gated feature
+- GIVEN a request to a gated endpoint
+- WHEN the policy evaluates the flag
+- THEN a standardized log entry is emitted indicating `feature_name` and `status` (enabled/disabled)

--- a/openspec/changes/rollout-flags-and-observability-hardening/tasks.md
+++ b/openspec/changes/rollout-flags-and-observability-hardening/tasks.md
@@ -1,0 +1,25 @@
+# Tasks: Rollout Flags and Observability Hardening
+
+## Phase 1: PR1 - Policy Foundation
+
+- [x] PR1.1 Create `src/lib/hardeningPolicy.ts` with typed flag constants, secure-default env parsing, and reusable hardening event/header builders.
+- [x] PR1.2 Extend `tests/operational-hardening.test.ts` for explicit `true`, missing/malformed fallback, and deterministic `feature_name`/`status` telemetry assertions.
+- [x] PR1.3 Document rollout flags and restart/redeploy semantics in `.env.example`, `README.md`, and `docs/runbooks/production-hardening.md`.
+- Verification: `bun run check:types && bun test tests/operational-hardening.test.ts`
+- Risk guard / rollback: keep defaults secure-on and headers additive only; if parsing or telemetry regresses, revert this PR with no feature behavior change.
+
+## Phase 2: PR2 - OTP and Export Wiring
+
+- [x] PR2.1 Modify `src/services/authService.ts`, `src/app/api/otp/route.ts`, and `src/app/api/otp/validate/route.ts` to resolve `OTP_HARDENING_ENABLED`, branch strict vs permissive OTP flow, and attach hardening headers without moving route logic client-side.
+- [x] PR2.2 Modify `src/services/exportRangeService.ts`, `src/app/api/admin/export/users/route.ts`, and `src/app/api/admin/export/consents/route.ts` to resolve `EXPORT_BOUNDS_ENFORCED`, keep the existing 5000-row cap in fallback mode, and emit export hardening telemetry.
+- [x] PR2.3 Extend `tests/auth-hardening.test.ts` and `tests/operational-hardening.test.ts` for OTP lockout on/off, export bounds reject/bypass behavior, and response-header observability.
+- Verification: `bun run check:types && bun test tests/auth-hardening.test.ts tests/operational-hardening.test.ts`
+- Risk guard / rollback: preserve current strict codepaths as the default branch and keep the fallback bounded by the current row cap; rollback is a clean revert or env flip back to `true`.
+
+## Phase 3: PR3 - SEO Wiring
+
+- [x] PR3.1 Modify `src/lib/seo.ts`, `src/app/robots.ts`, `src/app/sitemap.ts`, and `src/app/(public)/layout.tsx` to read `PUBLIC_SEO_ENABLED` from the shared policy and keep metadata generation server-side.
+- [x] PR3.2 Extend `tests/seo-public.test.ts` for robots allow/disallow output, sitemap visibility, and `noindex,nofollow` vs indexable metadata scenarios.
+- [x] PR3.3 Update `docs/runbooks/production-hardening.md` with SEO rollout smoke checks covering `robots.txt`, sitemap, and page metadata after deploy.
+- Verification: `bun run check:types && bun test tests/seo-public.test.ts`
+- Risk guard / rollback: ship SEO last so public crawling changes stay isolated; rollback is `PUBLIC_SEO_ENABLED=false` plus redeploy, or revert PR3 if metadata drift appears.

--- a/openspec/changes/rollout-flags-and-observability-hardening/verify-report.md
+++ b/openspec/changes/rollout-flags-and-observability-hardening/verify-report.md
@@ -1,0 +1,128 @@
+## Verification Report
+
+**Change**: `rollout-flags-and-observability-hardening`
+**Version**: N/A
+**Mode**: Standard
+**Artifact Store**: hybrid
+**Date**: 2026-04-05
+
+Mode resolution: cached SDD init context still marks `strict_tdd` disabled, `openspec/config.yaml` is absent, and the repo now has Bun tests. This verify run therefore used **Standard** mode, executed the user-required Bun commands directly, and treated the old testing-capabilities artifact as stale for command discovery.
+
+---
+
+### Completeness
+
+| Metric | Value |
+|--------|-------|
+| Tasks total | 9 |
+| Tasks complete | 9 |
+| Tasks incomplete | 0 |
+
+All checklist items in `openspec/changes/rollout-flags-and-observability-hardening/tasks.md` are marked complete.
+
+---
+
+### Build & Tests Execution
+
+**Type Check**: PASS
+
+```text
+$ bun run check:types
+$ tsc --noEmit
+Exit code: 0
+```
+
+**Tests**: PASS
+
+```text
+$ bun test tests/operational-hardening.test.ts
+14 pass, 0 fail, 0 skipped
+
+$ bun test tests/auth-hardening.test.ts tests/operational-hardening.test.ts
+18 pass, 0 fail, 0 skipped
+
+$ bun test tests/seo-public.test.ts
+3 pass, 0 fail, 0 skipped
+```
+
+**Coverage**: Not available
+
+- No `openspec/config.yaml` coverage rule exists.
+- No coverage script or threshold is configured in `package.json`.
+
+---
+
+### Spec Compliance Matrix
+
+| Requirement | Scenario | Test | Result |
+|-------------|----------|------|--------|
+| Rollout Policy - Flag Resolution | Flag enabled explicitly | `tests/operational-hardening.test.ts > honors explicit true rollout flags` | COMPLIANT |
+| Rollout Policy - Flag Resolution | Flag missing or malformed | `tests/operational-hardening.test.ts > defaults missing and malformed rollout flags to secure-on with deterministic warnings` | COMPLIANT |
+| Rollout Policy - Observability Logging | Operation uses gated feature | `tests/operational-hardening.test.ts > emits deterministic policy telemetry markers` | COMPLIANT |
+| Hardened OTP - Hardening Enabled | OTP limits enforced | `tests/auth-hardening.test.ts > returns OTP_LOCKED after repeated incorrect validation attempts` | COMPLIANT |
+| Hardened OTP - Hardening Disabled (Fallback) | OTP limits bypassed | `tests/auth-hardening.test.ts > bypasses OTP request throttles when hardening is disabled` + `tests/auth-hardening.test.ts > bypasses OTP validation lockouts when hardening is disabled` | COMPLIANT |
+| Bounded Export - Export Bounds Enforced | Bounds check passes | `tests/operational-hardening.test.ts > returns bounded metadata for valid export ranges` | COMPLIANT |
+| Bounded Export - Export Bounds Enforced | Bounds check fails | `tests/operational-hardening.test.ts > returns 400 with hardening headers from /api/admin/export/users when enforced bounds reject the range` + `tests/operational-hardening.test.ts > returns 400 with hardening headers from /api/admin/export/consents when enforced bounds reject the range` | COMPLIANT |
+| Bounded Export - Export Bounds Disabled (Fallback) | Unbounded export allowed | `tests/operational-hardening.test.ts > returns 200 with final headers from /api/admin/export/users when bounds are disabled` + `tests/operational-hardening.test.ts > returns 200 with final headers from /api/admin/export/consents when bounds are disabled` | COMPLIANT |
+| Public SEO - SEO Enabled | Search engines allowed | `tests/seo-public.test.ts > publishes robots, sitemap, and metadata when public SEO is enabled` | COMPLIANT |
+| Public SEO - SEO Disabled | Search engines blocked | `tests/seo-public.test.ts > blocks robots, hides sitemap, and returns noindex metadata when SEO is disabled` | COMPLIANT |
+
+**Compliance summary**: 10/10 scenarios compliant
+
+---
+
+### Correctness (Static - Structural Evidence)
+
+| Requirement | Status | Notes |
+|------------|--------|-------|
+| Rollout policy resolution and telemetry | PASS | `src/lib/hardeningPolicy.ts` centralizes typed flag parsing, secure defaults, warning payloads, additive headers, and structured `console.info` events. |
+| OTP hardening gating | PASS | `src/services/authService.ts` evaluates policy once per request/validate flow, branches strict vs permissive execution, and returns hardening headers from both paths; route handlers in `src/app/api/otp/route.ts` and `src/app/api/otp/validate/route.ts` forward those headers at the boundary. |
+| Export bounds gating | PASS | `src/services/exportRangeService.ts` resolves bounded vs fallback ranges, and route handlers in `src/app/api/admin/export/users/route.ts` and `src/app/api/admin/export/consents/route.ts` emit final `X-Hardening-*` plus `X-Export-*` headers on both error and success responses. |
+| Public SEO gating | PASS | `src/lib/seo.ts`, `src/app/robots.ts`, `src/app/sitemap.ts`, and `src/app/(public)/layout.tsx` keep SEO behavior server-side and policy-driven. |
+| Documentation and rollout guidance | PASS | `.env.example`, `README.md`, and `docs/runbooks/production-hardening.md` document defaults, restart/redeploy semantics, and smoke checks. |
+
+---
+
+### Coherence (Design)
+
+| Decision | Followed? | Notes |
+|----------|-----------|-------|
+| Shared policy source instead of inline `process.env` | PASS | OTP, export, and SEO surfaces use `src/lib/hardeningPolicy.ts`. |
+| Structured logs plus additive headers | PASS | Structured `console.warn` / `console.info` payloads and additive headers are present without introducing new infra. |
+| Explicit strict/permissive OTP branching | PASS | `requestOtpChallenge(...)` and `validateOtpChallengeRequest(...)` branch on the policy flag without moving logic client-side. |
+| File change plan | PASS | The files named in the design table are present and aligned, including route handlers, services, tests, and docs. |
+| Disabled export safety cap | PASS | `src/services/adminExportService.ts` uses `range.metadata.rowCap` for bounded and fallback reads, preserving the 5000-row cap. |
+
+---
+
+### Evidence Gap Closure
+
+| Prior warning | Current evidence | Status |
+|---------------|------------------|--------|
+| Direct route-level export boundary/header evidence | `tests/operational-hardening.test.ts` now calls `handleUsersExport(...)` and `handleConsentsExport(...)` directly and asserts `400/200` status plus final `X-Hardening-*` and `X-Export-*` headers | CLOSED |
+| Explicit OTP disabled-path structured log assertions | `tests/auth-hardening.test.ts` now captures `console.info` in both disabled request and disabled validate paths and asserts `feature_name`, `status`, `source`, and `route` | CLOSED |
+
+---
+
+### Issues Found
+
+**CRITICAL**
+
+None.
+
+**WARNING**
+
+None.
+
+**SUGGESTION**
+
+- Refresh the cached testing-capabilities artifact so future verify runs do not need to explain stale init-era detection.
+- Add optional coverage tooling later if the team wants percentage-based verify gates.
+
+---
+
+### Verdict
+
+PASS
+
+All required Bun verification commands pass, all 10 spec scenarios have passing behavioral evidence, and both previously reported warning gaps are now closed.

--- a/src/app/(public)/layout.tsx
+++ b/src/app/(public)/layout.tsx
@@ -1,8 +1,10 @@
 import type { Metadata } from 'next'
-import { INDEXABLE_ROBOTS } from '@/lib/seo'
+import { buildPublicRobotsMetadata } from '@/lib/seo'
 
-export const metadata: Metadata = {
-	robots: INDEXABLE_ROBOTS,
+export function generateMetadata(): Metadata {
+	return {
+		robots: buildPublicRobotsMetadata(),
+	}
 }
 
 export default function PublicLayout({

--- a/src/app/api/admin/export/consents/route.ts
+++ b/src/app/api/admin/export/consents/route.ts
@@ -43,7 +43,7 @@ export async function handleConsentsExport(
 	}
 
 	const { searchParams } = new URL(request.url)
-	let range
+	let range: ExportRangeResolution
 
 	try {
 		range = resolveExportRange({

--- a/src/app/api/admin/export/consents/route.ts
+++ b/src/app/api/admin/export/consents/route.ts
@@ -4,15 +4,37 @@
  */
 import { type NextRequest, NextResponse } from 'next/server'
 import { verifyAdminTokenWithPermission } from '@/lib/adminAuth'
-import { apiHandler } from '@/lib/apiHandler'
+import { ApiError, apiHandler } from '@/lib/apiHandler'
+import {
+	buildHardeningHeaders,
+	HARDENING_FLAG,
+	resolveHardeningFlag,
+} from '@/lib/hardeningPolicy'
 import { buildConsentsCsvExport } from '@/services/adminExportService'
 import {
+	buildExportFilenameLabel,
 	buildExportMetadataHeaders,
-	resolveBoundedExportRange,
+	type ExportRangeResolution,
+	resolveExportRange,
 } from '@/services/exportRangeService'
 
-export const GET = apiHandler(async (request: NextRequest) => {
-	const authResult = await verifyAdminTokenWithPermission(
+interface ConsentsExportRouteDeps {
+	verifyAdminTokenWithPermission: typeof verifyAdminTokenWithPermission
+	buildConsentsCsvExport: (
+		range: ExportRangeResolution,
+	) => Promise<{ csv: string; rowCount: number }>
+}
+
+const defaultConsentsExportRouteDeps: ConsentsExportRouteDeps = {
+	verifyAdminTokenWithPermission,
+	buildConsentsCsvExport,
+}
+
+export async function handleConsentsExport(
+	request: NextRequest,
+	deps: ConsentsExportRouteDeps = defaultConsentsExportRouteDeps,
+): Promise<NextResponse> {
+	const authResult = await deps.verifyAdminTokenWithPermission(
 		request,
 		'consents:export',
 	)
@@ -21,21 +43,50 @@ export const GET = apiHandler(async (request: NextRequest) => {
 	}
 
 	const { searchParams } = new URL(request.url)
-	const range = resolveBoundedExportRange({
-		from: searchParams.get('from') || undefined,
-		to: searchParams.get('to') || undefined,
-		field: 'signedAt',
-	})
+	let range
 
-	const { csv, rowCount } = await buildConsentsCsvExport(range)
-	const filename = `consentimientos_${range.metadata.from}_a_${range.metadata.to}.csv`
+	try {
+		range = resolveExportRange({
+			from: searchParams.get('from') || undefined,
+			to: searchParams.get('to') || undefined,
+			field: 'signedAt',
+			source: 'admin-export-consents',
+			route: '/api/admin/export/consents',
+		})
+	} catch (error) {
+		if (error instanceof ApiError) {
+			return NextResponse.json(
+				{
+					error: error.message,
+					code: error.code,
+					details: error.details,
+				},
+				{
+					status: error.statusCode,
+					headers: buildHardeningHeaders(
+						resolveHardeningFlag(HARDENING_FLAG.EXPORT_BOUNDS),
+					),
+				},
+			)
+		}
+
+		throw error
+	}
+
+	const { csv, rowCount } = await deps.buildConsentsCsvExport(range)
+	const filename = `consentimientos_${buildExportFilenameLabel(range.metadata)}.csv`
 
 	return new NextResponse(csv, {
 		status: 200,
 		headers: {
 			'Content-Type': 'text/csv; charset=utf-8',
 			'Content-Disposition': `attachment; filename="${filename}"`,
+			...range.hardening.headers,
 			...buildExportMetadataHeaders(range.metadata, rowCount),
 		},
 	})
-})
+}
+
+export const GET = apiHandler(async (request: NextRequest) =>
+	handleConsentsExport(request),
+)

--- a/src/app/api/admin/export/users/route.ts
+++ b/src/app/api/admin/export/users/route.ts
@@ -43,7 +43,7 @@ export async function handleUsersExport(
 	}
 
 	const { searchParams } = new URL(request.url)
-	let range
+	let range: ExportRangeResolution
 
 	try {
 		range = resolveExportRange({

--- a/src/app/api/admin/export/users/route.ts
+++ b/src/app/api/admin/export/users/route.ts
@@ -4,35 +4,89 @@
  */
 import { type NextRequest, NextResponse } from 'next/server'
 import { verifyAdminTokenWithPermission } from '@/lib/adminAuth'
-import { apiHandler } from '@/lib/apiHandler'
+import { ApiError, apiHandler } from '@/lib/apiHandler'
+import {
+	buildHardeningHeaders,
+	HARDENING_FLAG,
+	resolveHardeningFlag,
+} from '@/lib/hardeningPolicy'
 import { buildUsersCsvExport } from '@/services/adminExportService'
 import {
+	buildExportFilenameLabel,
 	buildExportMetadataHeaders,
-	resolveBoundedExportRange,
+	type ExportRangeResolution,
+	resolveExportRange,
 } from '@/services/exportRangeService'
 
-export const GET = apiHandler(async (request: NextRequest) => {
-	const authResult = await verifyAdminTokenWithPermission(request, 'users:view')
+interface UsersExportRouteDeps {
+	verifyAdminTokenWithPermission: typeof verifyAdminTokenWithPermission
+	buildUsersCsvExport: (
+		range: ExportRangeResolution,
+	) => Promise<{ csv: string; rowCount: number }>
+}
+
+const defaultUsersExportRouteDeps: UsersExportRouteDeps = {
+	verifyAdminTokenWithPermission,
+	buildUsersCsvExport,
+}
+
+export async function handleUsersExport(
+	request: NextRequest,
+	deps: UsersExportRouteDeps = defaultUsersExportRouteDeps,
+): Promise<NextResponse> {
+	const authResult = await deps.verifyAdminTokenWithPermission(
+		request,
+		'users:view',
+	)
 	if (!authResult.success) {
 		return authResult.response
 	}
 
 	const { searchParams } = new URL(request.url)
-	const range = resolveBoundedExportRange({
-		from: searchParams.get('from') || undefined,
-		to: searchParams.get('to') || undefined,
-		field: 'createdAt',
-	})
+	let range
 
-	const { csv, rowCount } = await buildUsersCsvExport(range)
-	const filename = `usuarios_${range.metadata.from}_a_${range.metadata.to}.csv`
+	try {
+		range = resolveExportRange({
+			from: searchParams.get('from') || undefined,
+			to: searchParams.get('to') || undefined,
+			field: 'createdAt',
+			source: 'admin-export-users',
+			route: '/api/admin/export/users',
+		})
+	} catch (error) {
+		if (error instanceof ApiError) {
+			return NextResponse.json(
+				{
+					error: error.message,
+					code: error.code,
+					details: error.details,
+				},
+				{
+					status: error.statusCode,
+					headers: buildHardeningHeaders(
+						resolveHardeningFlag(HARDENING_FLAG.EXPORT_BOUNDS),
+					),
+				},
+			)
+		}
+
+		throw error
+	}
+
+	const { csv, rowCount } = await deps.buildUsersCsvExport(range)
+	const filename = `usuarios_${buildExportFilenameLabel(range.metadata)}.csv`
 
 	return new NextResponse(csv, {
 		status: 200,
 		headers: {
 			'Content-Type': 'text/csv; charset=utf-8',
 			'Content-Disposition': `attachment; filename="${filename}"`,
+			...range.hardening.headers,
 			...buildExportMetadataHeaders(range.metadata, rowCount),
 		},
 	})
-})
+}
+
+export const GET = apiHandler(async (request: NextRequest) =>
+	handleUsersExport(request),
+)

--- a/src/app/api/otp/route.ts
+++ b/src/app/api/otp/route.ts
@@ -35,6 +35,7 @@ export const POST = apiHandler(
 			email: payload.email,
 			cedula: payload.cedula,
 			clientIp: getClientIP(req),
+			route: '/api/otp',
 			rateLimitMax: RATE_LIMIT_MAX,
 			rateLimitWindowMinutes: RATE_LIMIT_WINDOW_MINUTES,
 			rateLimitIpMultiplier: RATE_LIMIT_IP_MULTIPLIER,

--- a/src/app/api/otp/validate/route.ts
+++ b/src/app/api/otp/validate/route.ts
@@ -19,6 +19,7 @@ export const POST = apiHandler(
 			email: payload.email,
 			cedula: payload.cedula,
 			code: payload.code,
+			route: '/api/otp/validate',
 			validationLimit: VALIDATION_LIMIT,
 			validationWindowMinutes: VALIDATION_WINDOW_MINUTES,
 		})

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,21 +1,6 @@
 import type { MetadataRoute } from 'next'
-import { APP_URL, PUBLIC_PATHS } from '@/lib/seo'
+import { buildPublicRobotsManifest } from '@/lib/seo'
 
 export default function robots(): MetadataRoute.Robots {
-	return {
-		rules: {
-			userAgent: '*',
-			allow: [...PUBLIC_PATHS],
-			disallow: [
-				'/admin/',
-				'/ingreso/',
-				'/otp/',
-				'/registro/',
-				'/consentimiento/',
-				'/exito/',
-			],
-		},
-		sitemap: `${APP_URL}/sitemap.xml`,
-		host: APP_URL,
-	}
+	return buildPublicRobotsManifest()
 }

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,13 +1,6 @@
 import type { MetadataRoute } from 'next'
-import { createCanonicalUrl, PUBLIC_PATHS } from '@/lib/seo'
+import { buildPublicSitemap } from '@/lib/seo'
 
 export default function sitemap(): MetadataRoute.Sitemap {
-	const now = new Date()
-
-	return PUBLIC_PATHS.map((pathname) => ({
-		url: createCanonicalUrl(pathname),
-		lastModified: now,
-		changeFrequency: 'monthly',
-		priority: 0.7,
-	}))
+	return buildPublicSitemap()
 }

--- a/src/lib/hardeningPolicy.ts
+++ b/src/lib/hardeningPolicy.ts
@@ -1,0 +1,193 @@
+export const HARDENING_FLAG = {
+	OTP_HARDENING: 'otp-hardening',
+	EXPORT_BOUNDS: 'export-bounds',
+	PUBLIC_SEO: 'public-seo',
+} as const
+
+export const HARDENING_FLAG_ENV_KEY = {
+	[HARDENING_FLAG.OTP_HARDENING]: 'OTP_HARDENING_ENABLED',
+	[HARDENING_FLAG.EXPORT_BOUNDS]: 'EXPORT_BOUNDS_ENFORCED',
+	[HARDENING_FLAG.PUBLIC_SEO]: 'PUBLIC_SEO_ENABLED',
+} as const
+
+export const HARDENING_POLICY_HEADER_VALUE = 'hardening.policy'
+
+export type HardeningFeatureName =
+	(typeof HARDENING_FLAG)[keyof typeof HARDENING_FLAG]
+
+export type HardeningStatus = 'enabled' | 'disabled' | 'defaulted'
+
+export type HardeningSource =
+	| 'otp-request'
+	| 'otp-validate'
+	| 'admin-export-users'
+	| 'admin-export-consents'
+	| 'robots'
+	| 'sitemap'
+	| 'public-metadata'
+
+export interface HardeningPolicy {
+	otpHardeningEnabled: boolean
+	exportBoundsEnabled: boolean
+	publicSeoEnabled: boolean
+}
+
+export interface HardeningFlagResolution {
+	enabled: boolean
+	featureName: HardeningFeatureName
+	envKey: (typeof HARDENING_FLAG_ENV_KEY)[HardeningFeatureName]
+	status: HardeningStatus
+	fallbackApplied: boolean
+	rawValue?: string
+}
+
+export interface HardeningEvent {
+	event_name: 'hardening.policy.evaluated'
+	feature_name: HardeningFeatureName
+	status: HardeningStatus
+	source: HardeningSource
+	env_key: string
+	fallback_applied: boolean
+	request_id?: string
+	route?: string
+	details?: Record<string, string | number | boolean>
+}
+
+export interface HardeningEvaluation extends HardeningFlagResolution {
+	headers: Record<string, string>
+	event: HardeningEvent
+}
+
+interface EvaluateHardeningFlagOptions {
+	featureName: HardeningFeatureName
+	source: HardeningSource
+	route?: string
+	requestId?: string
+	details?: Record<string, string | number | boolean>
+}
+
+const SECURE_DEFAULT_ENABLED = true
+
+function parseBooleanFlag(rawValue: string | undefined): boolean | null {
+	if (rawValue === undefined) {
+		return null
+	}
+
+	const normalizedValue = rawValue.trim().toLowerCase()
+
+	if (normalizedValue === 'true') {
+		return true
+	}
+
+	if (normalizedValue === 'false') {
+		return false
+	}
+
+	return null
+}
+
+function buildFallbackWarningPayload(
+	resolution: HardeningFlagResolution,
+): Record<string, string | boolean | null> {
+	return {
+		event_name: 'hardening.policy.defaulted',
+		feature_name: resolution.featureName,
+		status: resolution.status,
+		env_key: resolution.envKey,
+		fallback_applied: resolution.fallbackApplied,
+		default_enabled: SECURE_DEFAULT_ENABLED,
+		raw_value: resolution.rawValue ?? null,
+	}
+}
+
+export function resolveHardeningFlag(
+	featureName: HardeningFeatureName,
+): HardeningFlagResolution {
+	const envKey = HARDENING_FLAG_ENV_KEY[featureName]
+	const rawValue = process.env[envKey]
+	const parsedValue = parseBooleanFlag(rawValue)
+
+	if (parsedValue === null) {
+		const resolution: HardeningFlagResolution = {
+			enabled: SECURE_DEFAULT_ENABLED,
+			featureName,
+			envKey,
+			status: 'defaulted',
+			fallbackApplied: true,
+			rawValue,
+		}
+
+		console.warn(
+			'[HardeningPolicy] Falling back to secure default',
+			buildFallbackWarningPayload(resolution),
+		)
+
+		return resolution
+	}
+
+	return {
+		enabled: parsedValue,
+		featureName,
+		envKey,
+		status: parsedValue ? 'enabled' : 'disabled',
+		fallbackApplied: false,
+		rawValue,
+	}
+}
+
+export function buildHardeningHeaders(
+	resolution: HardeningFlagResolution,
+): Record<string, string> {
+	return {
+		'X-Hardening-Policy': HARDENING_POLICY_HEADER_VALUE,
+		'X-Hardening-Feature': resolution.featureName,
+		'X-Hardening-Status': resolution.status,
+	}
+}
+
+export function buildHardeningEvent(
+	resolution: HardeningFlagResolution,
+	options: Omit<EvaluateHardeningFlagOptions, 'featureName'>,
+): HardeningEvent {
+	return {
+		event_name: 'hardening.policy.evaluated',
+		feature_name: resolution.featureName,
+		status: resolution.status,
+		source: options.source,
+		env_key: resolution.envKey,
+		fallback_applied: resolution.fallbackApplied,
+		request_id: options.requestId,
+		route: options.route,
+		details: options.details,
+	}
+}
+
+export function evaluateHardeningFlag(
+	options: EvaluateHardeningFlagOptions,
+): HardeningEvaluation {
+	const resolution = resolveHardeningFlag(options.featureName)
+	const event = buildHardeningEvent(resolution, {
+		source: options.source,
+		route: options.route,
+		requestId: options.requestId,
+		details: options.details,
+	})
+
+	console.info('[HardeningPolicy] Evaluated feature policy', event)
+
+	return {
+		...resolution,
+		headers: buildHardeningHeaders(resolution),
+		event,
+	}
+}
+
+export function resolveHardeningPolicy(): HardeningPolicy {
+	return {
+		otpHardeningEnabled: resolveHardeningFlag(HARDENING_FLAG.OTP_HARDENING)
+			.enabled,
+		exportBoundsEnabled: resolveHardeningFlag(HARDENING_FLAG.EXPORT_BOUNDS)
+			.enabled,
+		publicSeoEnabled: resolveHardeningFlag(HARDENING_FLAG.PUBLIC_SEO).enabled,
+	}
+}

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -1,4 +1,5 @@
-import type { Metadata } from 'next'
+import type { Metadata, MetadataRoute } from 'next'
+import { evaluateHardeningFlag, HARDENING_FLAG } from '@/lib/hardeningPolicy'
 
 export const APP_NAME = 'Jumping Park'
 export const APP_DESCRIPTION =
@@ -32,4 +33,70 @@ export const INDEXABLE_ROBOTS: NonNullable<Metadata['robots']> = {
 
 export function createCanonicalUrl(pathname = '/'): string {
 	return new URL(pathname, APP_URL).toString()
+}
+
+export function buildPublicRobotsMetadata(): NonNullable<Metadata['robots']> {
+	const policy = evaluateHardeningFlag({
+		featureName: HARDENING_FLAG.PUBLIC_SEO,
+		source: 'public-metadata',
+		route: '/(public)',
+	})
+
+	return policy.enabled ? INDEXABLE_ROBOTS : NON_INDEXABLE_ROBOTS
+}
+
+export function buildPublicRobotsManifest(): MetadataRoute.Robots {
+	const policy = evaluateHardeningFlag({
+		featureName: HARDENING_FLAG.PUBLIC_SEO,
+		source: 'robots',
+		route: '/robots.txt',
+	})
+
+	if (!policy.enabled) {
+		return {
+			rules: {
+				userAgent: '*',
+				disallow: ['/'],
+			},
+			host: APP_URL,
+		}
+	}
+
+	return {
+		rules: {
+			userAgent: '*',
+			allow: [...PUBLIC_PATHS],
+			disallow: [
+				'/admin/',
+				'/ingreso/',
+				'/otp/',
+				'/registro/',
+				'/consentimiento/',
+				'/exito/',
+			],
+		},
+		sitemap: `${APP_URL}/sitemap.xml`,
+		host: APP_URL,
+	}
+}
+
+export function buildPublicSitemap(): MetadataRoute.Sitemap {
+	const policy = evaluateHardeningFlag({
+		featureName: HARDENING_FLAG.PUBLIC_SEO,
+		source: 'sitemap',
+		route: '/sitemap.xml',
+	})
+
+	if (!policy.enabled) {
+		return []
+	}
+
+	const now = new Date()
+
+	return PUBLIC_PATHS.map((pathname) => ({
+		url: createCanonicalUrl(pathname),
+		lastModified: now,
+		changeFrequency: 'monthly',
+		priority: 0.7,
+	}))
 }

--- a/src/services/adminExportService.ts
+++ b/src/services/adminExportService.ts
@@ -1,4 +1,4 @@
-import { getDocsByDateRange } from '@/lib/firestoreService'
+import { getDocs, getDocsByDateRange } from '@/lib/firestoreService'
 import type { ExportRangeResolution } from '@/services/exportRangeService'
 import type { Consent, UserProfile } from '@/types/firestore'
 
@@ -50,14 +50,17 @@ function buildCsv(headers: string[], rows: string[]): string {
 export async function buildUsersCsvExport(
 	range: ExportRangeResolution,
 ): Promise<{ csv: string; rowCount: number }> {
-	const users = await getDocsByDateRange('users', {
-		field: 'createdAt',
-		from: range.fromDate,
-		to: range.toDate,
-		orderBy: 'createdAt',
-		orderDirection: 'desc',
-		limit: 5000,
-	})
+	const users =
+		range.fromDate && range.toDate
+			? await getDocsByDateRange('users', {
+					field: 'createdAt',
+					from: range.fromDate,
+					to: range.toDate,
+					orderBy: 'createdAt',
+					orderDirection: 'desc',
+					limit: range.metadata.rowCap,
+			  })
+			: await getDocs('users', range.metadata.rowCap)
 
 	const headers = [
 		'Cédula',
@@ -94,14 +97,17 @@ export async function buildUsersCsvExport(
 export async function buildConsentsCsvExport(
 	range: ExportRangeResolution,
 ): Promise<{ csv: string; rowCount: number }> {
-	const consents = await getDocsByDateRange('consents', {
-		field: 'signedAt',
-		from: range.fromDate,
-		to: range.toDate,
-		orderBy: 'signedAt',
-		orderDirection: 'desc',
-		limit: 5000,
-	})
+	const consents =
+		range.fromDate && range.toDate
+			? await getDocsByDateRange('consents', {
+					field: 'signedAt',
+					from: range.fromDate,
+					to: range.toDate,
+					orderBy: 'signedAt',
+					orderDirection: 'desc',
+					limit: range.metadata.rowCap,
+			  })
+			: await getDocs('consents', range.metadata.rowCap)
 
 	const headers = [
 		'Consecutivo',

--- a/src/services/authService.ts
+++ b/src/services/authService.ts
@@ -5,6 +5,7 @@ import {
 	getDocRef,
 	runInTransaction,
 } from '@/lib/firestoreService'
+import { evaluateHardeningFlag, HARDENING_FLAG } from '@/lib/hardeningPolicy'
 import { isExpired, toJsDate } from '@/lib/utils/dateUtils'
 import { sendOtpEmail as sendOtpViaEmail } from '@/services/emailService'
 import { checkRateLimit } from '@/services/rateLimitService'
@@ -464,6 +465,7 @@ interface RequestOtpChallengeParams {
 	email?: string
 	cedula?: string
 	clientIp?: string
+	route?: string
 	rateLimitMax: number
 	rateLimitWindowMinutes: number
 	rateLimitIpMultiplier: number
@@ -474,6 +476,7 @@ interface ValidateOtpChallengeRequestParams {
 	email?: string
 	cedula?: string
 	code: string
+	route?: string
 	validationLimit: number
 	validationWindowMinutes: number
 }
@@ -491,7 +494,16 @@ export interface ValidateOtpChallengeRequestDeps {
 	getActiveOtp: typeof getActiveOtp
 	checkRateLimit: typeof checkRateLimit
 	validateOtp: typeof validateOtp
+	validateOtpPermissive: typeof validateOtpPermissive
 	createOtpSession: typeof createOtpSession
+}
+
+function mergeHeaders(
+	...headerSets: Array<Record<string, string> | undefined>
+): Record<string, string> | undefined {
+	const merged = Object.assign({}, ...headerSets.filter(Boolean))
+
+	return Object.keys(merged).length > 0 ? merged : undefined
 }
 
 function getRequestOtpChallengeDeps(): RequestOtpChallengeDeps {
@@ -510,7 +522,94 @@ function getValidateOtpChallengeRequestDeps(): ValidateOtpChallengeRequestDeps {
 		getActiveOtp,
 		checkRateLimit,
 		validateOtp,
+		validateOtpPermissive,
 		createOtpSession,
+	}
+}
+
+export async function validateOtpPermissive(
+	email: string,
+	code: string,
+): Promise<ValidateOtpResult> {
+	try {
+		const challengeRef = getDocRef(OTP_CHALLENGES_COLLECTION, email)
+
+		const result = await runInTransaction(async (transaction) => {
+			const challengeSnapshot = await transaction.get(challengeRef)
+
+			if (!challengeSnapshot.exists) {
+				const legacyChallenge = await getDocById<OtpRecord>(
+					LEGACY_OTP_COLLECTION,
+					email,
+				)
+
+				if (!legacyChallenge || !isOtpChallenge(legacyChallenge)) {
+					return {
+						valid: false,
+						message: 'Codigo no solicitado o expirado',
+						code: 'OTP_EXPIRED' as const,
+					}
+				}
+
+				if (isExpired(legacyChallenge.expiresAt)) {
+					await deleteChallenge(email)
+					return {
+						valid: false,
+						message: 'Codigo expirado',
+						code: 'OTP_EXPIRED' as const,
+					}
+				}
+
+				if (legacyChallenge.code !== code) {
+					return {
+						valid: false,
+						message: 'Codigo incorrecto',
+						code: 'OTP_INVALID' as const,
+					}
+				}
+
+				return { valid: true, message: 'OTP valido' } as const
+			}
+
+			const challenge = challengeSnapshot.data() as OtpChallenge
+
+			if (isExpired(challenge.expiresAt)) {
+				transaction.delete(challengeRef)
+				return {
+					valid: false,
+					message: 'Codigo expirado',
+					code: 'OTP_EXPIRED' as const,
+				}
+			}
+
+			if (challenge.code !== code) {
+				return {
+					valid: false,
+					message: 'Codigo incorrecto',
+					code: 'OTP_INVALID' as const,
+				}
+			}
+
+			transaction.update(challengeRef, {
+				attempts: 0,
+				lockedUntil: null,
+				lastValidatedAt: new Date(),
+			})
+
+			return { valid: true, message: 'OTP valido' } as const
+		})
+
+		return result
+	} catch (error) {
+		console.error('[AuthService] Error validando OTP en modo permisivo:', {
+			email: maskEmail(email),
+			error: toSafeErrorMessage(error),
+		})
+		return {
+			valid: false,
+			message: 'No se pudo validar el OTP',
+			code: 'OTP_ERROR',
+		}
 	}
 }
 
@@ -518,6 +617,16 @@ export async function requestOtpChallenge(
 	params: RequestOtpChallengeParams,
 	deps: RequestOtpChallengeDeps = getRequestOtpChallengeDeps(),
 ): Promise<SendOtpRequestResult> {
+	const hardening = evaluateHardeningFlag({
+		featureName: HARDENING_FLAG.OTP_HARDENING,
+		source: 'otp-request',
+		route: params.route ?? '/api/otp',
+		details: {
+			has_cedula: Boolean(params.cedula),
+			has_email: Boolean(params.email),
+		},
+	})
+
 	let targetEmail = params.email
 
 	if (!targetEmail && params.cedula) {
@@ -528,6 +637,7 @@ export async function requestOtpChallenge(
 				status: 'bad_request',
 				httpStatus: 404,
 				body: { error: 'Usuario no encontrado' },
+				headers: hardening.headers,
 			}
 		}
 
@@ -536,6 +646,7 @@ export async function requestOtpChallenge(
 				status: 'bad_request',
 				httpStatus: 404,
 				body: { error: 'Usuario sin email registrado' },
+				headers: hardening.headers,
 			}
 		}
 
@@ -547,6 +658,31 @@ export async function requestOtpChallenge(
 			status: 'bad_request',
 			httpStatus: 400,
 			body: { error: 'Faltan datos' },
+			headers: hardening.headers,
+		}
+	}
+
+	if (!hardening.enabled) {
+		const otp = params.codeGenerator()
+		await deps.saveOtp(targetEmail, otp)
+		const emailResult = await deps.sendOtpEmail(targetEmail, otp)
+
+		if (!emailResult.success) {
+			return {
+				status: 'bad_request',
+				httpStatus: 500,
+				body: { error: emailResult.error ?? 'No se pudo enviar el OTP' },
+				headers: hardening.headers,
+			}
+		}
+
+		return {
+			status: 'ok',
+			httpStatus: 200,
+			body: {
+				message: 'OTP enviado',
+			},
+			headers: hardening.headers,
 		}
 	}
 
@@ -562,9 +698,10 @@ export async function requestOtpChallenge(
 					retryAfter: activeOtp.retryAfterSeconds,
 					code: 'OTP_RATE_LIMITED',
 				},
-				headers: {
-					'Retry-After': String(activeOtp.retryAfterSeconds),
-				},
+				headers: mergeHeaders(
+					{ 'Retry-After': String(activeOtp.retryAfterSeconds) },
+					hardening.headers,
+				),
 			}
 		}
 
@@ -578,9 +715,10 @@ export async function requestOtpChallenge(
 				otpAlreadySent: true,
 				remainingMinutes: activeOtp.remainingMinutes,
 			},
-			headers: {
-				'Retry-After': String(activeOtp.remainingMinutes * 60),
-			},
+			headers: mergeHeaders(
+				{ 'Retry-After': String(activeOtp.remainingMinutes * 60) },
+				hardening.headers,
+			),
 		}
 	}
 
@@ -602,9 +740,10 @@ export async function requestOtpChallenge(
 				retryAfter: primaryRateLimit.retryAfterSeconds,
 				code: 'OTP_RATE_LIMITED',
 			},
-			headers: {
-				'Retry-After': String(primaryRateLimit.retryAfterSeconds),
-			},
+			headers: mergeHeaders(
+				{ 'Retry-After': String(primaryRateLimit.retryAfterSeconds) },
+				hardening.headers,
+			),
 		}
 	}
 
@@ -624,9 +763,10 @@ export async function requestOtpChallenge(
 					retryAfter: ipRateLimit.retryAfterSeconds,
 					code: 'OTP_RATE_LIMITED',
 				},
-				headers: {
-					'Retry-After': String(ipRateLimit.retryAfterSeconds),
-				},
+				headers: mergeHeaders(
+					{ 'Retry-After': String(ipRateLimit.retryAfterSeconds) },
+					hardening.headers,
+				),
 			}
 		}
 	}
@@ -640,6 +780,7 @@ export async function requestOtpChallenge(
 			status: 'bad_request',
 			httpStatus: 500,
 			body: { error: emailResult.error ?? 'No se pudo enviar el OTP' },
+			headers: hardening.headers,
 		}
 	}
 
@@ -650,6 +791,7 @@ export async function requestOtpChallenge(
 			message: 'OTP enviado',
 			remaining: primaryRateLimit.remaining,
 		},
+		headers: hardening.headers,
 	}
 }
 
@@ -658,6 +800,16 @@ export async function validateOtpChallengeRequest(
 	deps: ValidateOtpChallengeRequestDeps =
 		getValidateOtpChallengeRequestDeps(),
 ): Promise<ValidateOtpRequestResult> {
+	const hardening = evaluateHardeningFlag({
+		featureName: HARDENING_FLAG.OTP_HARDENING,
+		source: 'otp-validate',
+		route: params.route ?? '/api/otp/validate',
+		details: {
+			has_cedula: Boolean(params.cedula),
+			has_email: Boolean(params.email),
+		},
+	})
+
 	const context = await deps.resolveOtpValidationContext({
 		email: params.email,
 		cedula: params.cedula,
@@ -669,6 +821,7 @@ export async function validateOtpChallengeRequest(
 				status: 'not_found',
 				httpStatus: 404,
 				body: { success: false, error: 'Usuario no encontrado' },
+				headers: hardening.headers,
 			}
 		}
 
@@ -676,6 +829,35 @@ export async function validateOtpChallengeRequest(
 			status: 'bad_request',
 			httpStatus: 400,
 			body: { success: false, error: 'Faltan datos (Email no encontrado)' },
+			headers: hardening.headers,
+		}
+	}
+
+	if (!hardening.enabled) {
+		const result = await deps.validateOtpPermissive(context.targetEmail, params.code)
+
+		if (!result.valid) {
+			return {
+				status: 'not_found',
+				httpStatus: 404,
+				body: { success: false, error: result.message },
+				headers: hardening.headers,
+			}
+		}
+
+		if (params.cedula || context.userProfile?.uid) {
+			const userId = params.cedula || context.userProfile?.uid || ''
+			await deps.createOtpSession(userId, context.targetEmail)
+		}
+
+		return {
+			status: 'ok',
+			httpStatus: 200,
+			body: {
+				success: true,
+				userData: context.userProfile ?? undefined,
+			},
+			headers: hardening.headers,
 		}
 	}
 
@@ -693,9 +875,10 @@ export async function validateOtpChallengeRequest(
 				retryAfter,
 				code: 'OTP_LOCKED',
 			},
-			headers: {
-				'Retry-After': String(retryAfter),
-			},
+			headers: mergeHeaders(
+				{ 'Retry-After': String(retryAfter) },
+				hardening.headers,
+			),
 		}
 	}
 
@@ -718,9 +901,10 @@ export async function validateOtpChallengeRequest(
 				retryAfter: validationBudget.retryAfterSeconds,
 				code: 'OTP_RATE_LIMITED',
 			},
-			headers: {
-				'Retry-After': String(validationBudget.retryAfterSeconds),
-			},
+			headers: mergeHeaders(
+				{ 'Retry-After': String(validationBudget.retryAfterSeconds) },
+				hardening.headers,
+			),
 		}
 	}
 
@@ -739,9 +923,10 @@ export async function validateOtpChallengeRequest(
 					retryAfter,
 					code: 'OTP_LOCKED',
 				},
-				headers: {
-					'Retry-After': String(retryAfter),
-				},
+				headers: mergeHeaders(
+					{ 'Retry-After': String(retryAfter) },
+					hardening.headers,
+				),
 			}
 		}
 
@@ -749,6 +934,7 @@ export async function validateOtpChallengeRequest(
 			status: 'not_found',
 			httpStatus: 404,
 			body: { success: false, error: result.message },
+			headers: hardening.headers,
 		}
 	}
 
@@ -764,5 +950,6 @@ export async function validateOtpChallengeRequest(
 			success: true,
 			userData: context.userProfile ?? undefined,
 		},
+		headers: hardening.headers,
 	}
 }

--- a/src/services/exportRangeService.ts
+++ b/src/services/exportRangeService.ts
@@ -1,4 +1,10 @@
 import { ApiError } from '@/lib/apiHandler'
+import {
+	evaluateHardeningFlag,
+	HARDENING_FLAG,
+	type HardeningEvaluation,
+	type HardeningSource,
+} from '@/lib/hardeningPolicy'
 
 const EXPORT_RANGE_ERROR = {
 	REQUIRED: 'EXPORT_RANGE_REQUIRED',
@@ -7,28 +13,36 @@ const EXPORT_RANGE_ERROR = {
 } as const
 
 export const EXPORT_RANGE_MAX_DAYS = 30
+export const EXPORT_FALLBACK_ROW_CAP = 5000
+
+const EXPORT_RANGE_MIN_DATE = new Date('1970-01-01T00:00:00.000Z')
+const EXPORT_RANGE_MAX_DATE = new Date('9999-12-31T23:59:59.999Z')
 
 export interface ExportRangeInput {
 	from?: string
 	to?: string
 	field: string
+	source?: HardeningSource
+	route?: string
 }
 
 export interface ExportRangeMetadata {
 	field: string
-	from: string
-	to: string
-	dayCount: number
+	from: string | null
+	to: string | null
+	dayCount: number | null
 	maxDays: number
-	bounded: true
+	bounded: boolean
 	capped: false
 	rejected: false
+	rowCap: number
 }
 
 export interface ExportRangeResolution {
-	fromDate: Date
-	toDate: Date
+	fromDate: Date | null
+	toDate: Date | null
 	metadata: ExportRangeMetadata
+	hardening: HardeningEvaluation
 }
 
 function parseDateOnly(value: string, boundary: 'start' | 'end'): Date {
@@ -59,12 +73,30 @@ function parseDateOnly(value: string, boundary: 'start' | 'end'): Date {
 
 function calculateInclusiveDayCount(fromDate: Date, toDate: Date): number {
 	const millisecondsPerDay = 24 * 60 * 60 * 1000
-	return Math.floor((toDate.getTime() - fromDate.getTime()) / millisecondsPerDay) + 1
+	return (
+		Math.floor((toDate.getTime() - fromDate.getTime()) / millisecondsPerDay) + 1
+	)
+}
+
+function evaluateExportBoundsPolicy(
+	input: ExportRangeInput,
+): HardeningEvaluation {
+	return evaluateHardeningFlag({
+		featureName: HARDENING_FLAG.EXPORT_BOUNDS,
+		source: input.source ?? 'admin-export-users',
+		route: input.route,
+		details: {
+			has_from: Boolean(input.from),
+			has_to: Boolean(input.to),
+		},
+	})
 }
 
 export function resolveBoundedExportRange(
 	input: ExportRangeInput,
 ): ExportRangeResolution {
+	const hardening = evaluateExportBoundsPolicy(input)
+
 	if (!input.from || !input.to) {
 		throw new ApiError(
 			'Los exports requieren un rango acotado con from y to.',
@@ -119,8 +151,78 @@ export function resolveBoundedExportRange(
 			bounded: true,
 			capped: false,
 			rejected: false,
+			rowCap: EXPORT_FALLBACK_ROW_CAP,
 		},
+		hardening,
 	}
+}
+
+export function resolveExportRange(
+	input: ExportRangeInput,
+): ExportRangeResolution {
+	const hardening = evaluateExportBoundsPolicy(input)
+
+	if (hardening.enabled) {
+		return {
+			...resolveBoundedExportRange(input),
+			hardening,
+		}
+	}
+
+	const parsedFrom = input.from ? parseDateOnly(input.from, 'start') : null
+	const parsedTo = input.to ? parseDateOnly(input.to, 'end') : null
+
+	if (
+		parsedFrom !== null &&
+		parsedTo !== null &&
+		parsedFrom.getTime() > parsedTo.getTime()
+	) {
+		throw new ApiError(
+			'La fecha inicial no puede ser mayor que la fecha final.',
+			400,
+			EXPORT_RANGE_ERROR.INVALID,
+		)
+	}
+
+	const fromDate = parsedFrom ?? (parsedTo ? EXPORT_RANGE_MIN_DATE : null)
+	const toDate = parsedTo ?? (parsedFrom ? EXPORT_RANGE_MAX_DATE : null)
+	const dayCount =
+		parsedFrom !== null && parsedTo !== null
+			? calculateInclusiveDayCount(parsedFrom, parsedTo)
+			: null
+
+	return {
+		fromDate,
+		toDate,
+		metadata: {
+			field: input.field,
+			from: input.from ?? null,
+			to: input.to ?? null,
+			dayCount,
+			maxDays: EXPORT_RANGE_MAX_DAYS,
+			bounded: fromDate !== null && toDate !== null,
+			capped: false,
+			rejected: false,
+			rowCap: EXPORT_FALLBACK_ROW_CAP,
+		},
+		hardening,
+	}
+}
+
+export function buildExportFilenameLabel(metadata: ExportRangeMetadata): string {
+	if (metadata.from && metadata.to) {
+		return `${metadata.from}_a_${metadata.to}`
+	}
+
+	if (metadata.from) {
+		return `${metadata.from}_en_adelante`
+	}
+
+	if (metadata.to) {
+		return `hasta_${metadata.to}`
+	}
+
+	return 'completo'
 }
 
 export function buildExportMetadataHeaders(
@@ -128,12 +230,14 @@ export function buildExportMetadataHeaders(
 	recordCount: number,
 ): Record<string, string> {
 	return {
-		'X-Export-Bounds': 'enforced',
+		'X-Export-Bounds': metadata.bounded ? 'enforced' : 'bypassed',
 		'X-Export-Range-Field': metadata.field,
-		'X-Export-Range-From': metadata.from,
-		'X-Export-Range-To': metadata.to,
-		'X-Export-Range-Days': String(metadata.dayCount),
+		'X-Export-Range-From': metadata.from ?? 'unbounded',
+		'X-Export-Range-To': metadata.to ?? 'unbounded',
+		'X-Export-Range-Days':
+			metadata.dayCount === null ? 'unbounded' : String(metadata.dayCount),
 		'X-Export-Max-Days': String(metadata.maxDays),
+		'X-Export-Row-Cap': String(metadata.rowCap),
 		'X-Export-Capped': String(metadata.capped),
 		'X-Export-Rejected': String(metadata.rejected),
 		'X-Export-Record-Count': String(recordCount),

--- a/tests/auth-hardening.test.ts
+++ b/tests/auth-hardening.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'bun:test'
 import type {
+	OtpChallengeState,
 	OtpValidationContext,
 	RequestOtpChallengeDeps,
 	SendOtpResult,
@@ -34,6 +35,44 @@ function createRateLimitedResult(): RateLimitResult {
 	}
 }
 
+function createLockedChallengeState(): OtpChallengeState {
+	return {
+		email: 'visitor@example.com',
+		code: '123456',
+		expiresAt: new Date(Date.now() + 300_000),
+		attempts: 5,
+		lockedUntil: new Date(Date.now() + 300_000),
+		lastSentAt: new Date(),
+		remainingMinutes: 5,
+		locked: true,
+		retryAfterSeconds: 300,
+	}
+}
+
+async function withEnv<T>(
+	key: string,
+	value: string | undefined,
+	callback: () => Promise<T>,
+): Promise<T> {
+	const previousValue = process.env[key]
+
+	if (value === undefined) {
+		delete process.env[key]
+	} else {
+		process.env[key] = value
+	}
+
+	try {
+		return await callback()
+	} finally {
+		if (previousValue === undefined) {
+			delete process.env[key]
+		} else {
+			process.env[key] = previousValue
+		}
+	}
+}
+
 function createRequestDeps(
 	overrides: Partial<RequestOtpChallengeDeps>,
 ): RequestOtpChallengeDeps {
@@ -59,6 +98,8 @@ function createValidationDeps(
 		getActiveOtp: async () => null,
 		checkRateLimit: async () => createAllowedRateLimitResult(4),
 		validateOtp: async () => ({ valid: true, message: 'OTP valido' }) as ValidateOtpResult,
+		validateOtpPermissive: async () =>
+			({ valid: true, message: 'OTP valido' }) as ValidateOtpResult,
 		createOtpSession: async () => undefined,
 		...overrides,
 	}
@@ -66,97 +107,242 @@ function createValidationDeps(
 
 describe('OTP hardening', () => {
 	it('rate limits OTP requests after the third request in five minutes', async () => {
-		let requestCount = 0
-		const deps = createRequestDeps({
-			checkRateLimit: async (identifier) => {
-				if (identifier.startsWith('otp:req:ip:')) {
-					return createAllowedRateLimitResult(8)
-				}
+		await withEnv('OTP_HARDENING_ENABLED', 'true', async () => {
+			let requestCount = 0
+			const deps = createRequestDeps({
+				checkRateLimit: async (identifier) => {
+					if (identifier.startsWith('otp:req:ip:')) {
+						return createAllowedRateLimitResult(8)
+					}
 
-				requestCount += 1
+					requestCount += 1
 
-				if (requestCount <= 3) {
-					return createAllowedRateLimitResult(3 - requestCount)
-				}
+					if (requestCount <= 3) {
+						return createAllowedRateLimitResult(3 - requestCount)
+					}
 
-				return createRateLimitedResult()
-			},
+					return createRateLimitedResult()
+				},
+			})
+
+			const attempts = []
+
+			for (let attempt = 0; attempt < 4; attempt += 1) {
+				attempts.push(
+					await requestOtpChallenge(
+						{
+							cedula: '12345678',
+							clientIp: '203.0.113.10',
+							route: '/api/otp',
+							rateLimitMax: 3,
+							rateLimitWindowMinutes: 5,
+							rateLimitIpMultiplier: 3,
+							codeGenerator: () => '123456',
+						},
+						deps,
+					),
+				)
+			}
+
+			expect(attempts[0]?.httpStatus).toBe(200)
+			expect(attempts[1]?.httpStatus).toBe(200)
+			expect(attempts[2]?.httpStatus).toBe(200)
+			expect(attempts[3]?.httpStatus).toBe(429)
+			expect(attempts[3]?.body.code).toBe('OTP_RATE_LIMITED')
+			expect(attempts[3]?.body.retryAfter).toBeGreaterThan(0)
+			expect(attempts[3]?.headers?.['Retry-After']).toBe('300')
+			expect(attempts[3]?.headers?.['X-Hardening-Feature']).toBe('otp-hardening')
+			expect(attempts[3]?.headers?.['X-Hardening-Status']).toBe('enabled')
 		})
-
-		const attempts = []
-
-		for (let attempt = 0; attempt < 4; attempt += 1) {
-			attempts.push(
-				await requestOtpChallenge(
-					{
-						cedula: '12345678',
-						clientIp: '203.0.113.10',
-						rateLimitMax: 3,
-						rateLimitWindowMinutes: 5,
-						rateLimitIpMultiplier: 3,
-						codeGenerator: () => '123456',
-					},
-					deps,
-				),
-			)
-		}
-
-		expect(attempts[0]?.httpStatus).toBe(200)
-		expect(attempts[1]?.httpStatus).toBe(200)
-		expect(attempts[2]?.httpStatus).toBe(200)
-		expect(attempts[3]?.httpStatus).toBe(429)
-		expect(attempts[3]?.body.code).toBe('OTP_RATE_LIMITED')
-		expect(attempts[3]?.body.retryAfter).toBeGreaterThan(0)
-		expect(attempts[3]?.headers?.['Retry-After']).toBe('300')
 	})
 
 	it('returns OTP_LOCKED after repeated incorrect validation attempts', async () => {
-		let attemptCount = 0
-		const deps = createValidationDeps({
-			validateOtp: async () => {
-				attemptCount += 1
+		await withEnv('OTP_HARDENING_ENABLED', 'true', async () => {
+			let attemptCount = 0
+			const deps = createValidationDeps({
+				validateOtp: async () => {
+					attemptCount += 1
 
-				if (attemptCount < 5) {
+					if (attemptCount < 5) {
+						return {
+							valid: false,
+							message: 'Codigo incorrecto',
+							code: 'OTP_INVALID',
+						} satisfies ValidateOtpResult
+					}
+
 					return {
 						valid: false,
-						message: 'Codigo incorrecto',
-						code: 'OTP_INVALID',
+						message: 'Session locked',
+						code: 'OTP_LOCKED',
+						retryAfterSeconds: 300,
 					} satisfies ValidateOtpResult
+				},
+			})
+
+			const attempts = []
+
+			for (let attempt = 0; attempt < 5; attempt += 1) {
+				attempts.push(
+					await validateOtpChallengeRequest(
+						{
+							cedula: '12345678',
+							code: '000000',
+							route: '/api/otp/validate',
+							validationLimit: 5,
+							validationWindowMinutes: 5,
+						},
+						deps,
+					),
+				)
+			}
+
+			expect(attempts[0]?.httpStatus).toBe(404)
+			expect(attempts[1]?.httpStatus).toBe(404)
+			expect(attempts[2]?.httpStatus).toBe(404)
+			expect(attempts[3]?.httpStatus).toBe(404)
+			expect(attempts[4]?.httpStatus).toBe(429)
+			expect(attempts[4]?.status).toBe('locked')
+			expect(attempts[4]?.body.code).toBe('OTP_LOCKED')
+			expect(attempts[4]?.body.error).toBe('Session locked')
+			expect(attempts[4]?.headers?.['Retry-After']).toBe('300')
+			expect(attempts[4]?.headers?.['X-Hardening-Status']).toBe('enabled')
+		})
+	})
+
+	it('bypasses OTP request throttles when hardening is disabled', async () => {
+		await withEnv('OTP_HARDENING_ENABLED', 'false', async () => {
+			const originalInfo = console.info
+			const events: unknown[][] = []
+			console.info = (...args: unknown[]) => {
+				events.push(args)
+			}
+
+			let savedCount = 0
+			let deliveredCount = 0
+
+			try {
+				const deps = createRequestDeps({
+					getActiveOtp: async () => createLockedChallengeState(),
+					checkRateLimit: async () => {
+						throw new Error('strict rate limiting should be bypassed')
+					},
+					saveOtp: async () => {
+						savedCount += 1
+					},
+					sendOtpEmail: async () => {
+						deliveredCount += 1
+						return { success: true }
+					},
+				})
+
+				const attempts = []
+
+				for (let attempt = 0; attempt < 4; attempt += 1) {
+					attempts.push(
+						await requestOtpChallenge(
+							{
+								cedula: '12345678',
+								clientIp: '203.0.113.10',
+								route: '/api/otp',
+								rateLimitMax: 3,
+								rateLimitWindowMinutes: 5,
+								rateLimitIpMultiplier: 3,
+								codeGenerator: () => '123456',
+							},
+							deps,
+						),
+					)
 				}
 
-				return {
-					valid: false,
-					message: 'Session locked',
-					code: 'OTP_LOCKED',
-					retryAfterSeconds: 300,
-				} satisfies ValidateOtpResult
-			},
+				expect(attempts.every((attempt) => attempt.httpStatus === 200)).toBe(true)
+				expect(savedCount).toBe(4)
+				expect(deliveredCount).toBe(4)
+				expect(attempts[0]?.headers?.['X-Hardening-Feature']).toBe('otp-hardening')
+				expect(attempts[0]?.headers?.['X-Hardening-Status']).toBe('disabled')
+				expect(events.length).toBe(4)
+				expect((events[0]?.[1] as Record<string, unknown>)?.feature_name).toBe(
+					'otp-hardening',
+				)
+				expect((events[0]?.[1] as Record<string, unknown>)?.status).toBe(
+					'disabled',
+				)
+				expect((events[0]?.[1] as Record<string, unknown>)?.source).toBe(
+					'otp-request',
+				)
+				expect((events[0]?.[1] as Record<string, unknown>)?.route).toBe('/api/otp')
+			} finally {
+				console.info = originalInfo
+			}
 		})
+	})
 
-		const attempts = []
+	it('bypasses OTP validation lockouts when hardening is disabled', async () => {
+		await withEnv('OTP_HARDENING_ENABLED', 'false', async () => {
+			const originalInfo = console.info
+			const events: unknown[][] = []
+			console.info = (...args: unknown[]) => {
+				events.push(args)
+			}
 
-		for (let attempt = 0; attempt < 5; attempt += 1) {
-			attempts.push(
-				await validateOtpChallengeRequest(
-					{
-						cedula: '12345678',
-						code: '000000',
-						validationLimit: 5,
-						validationWindowMinutes: 5,
+			let permissiveAttempts = 0
+
+			try {
+				const deps = createValidationDeps({
+					getActiveOtp: async () => createLockedChallengeState(),
+					checkRateLimit: async () => {
+						throw new Error('strict validation rate limiting should be bypassed')
 					},
-					deps,
-				),
-			)
-		}
+					validateOtp: async () => {
+						throw new Error('strict OTP validation should be bypassed')
+					},
+					validateOtpPermissive: async () => {
+						permissiveAttempts += 1
+						return {
+							valid: false,
+							message: 'Codigo incorrecto',
+							code: 'OTP_INVALID',
+						} satisfies ValidateOtpResult
+					},
+				})
 
-		expect(attempts[0]?.httpStatus).toBe(404)
-		expect(attempts[1]?.httpStatus).toBe(404)
-		expect(attempts[2]?.httpStatus).toBe(404)
-		expect(attempts[3]?.httpStatus).toBe(404)
-		expect(attempts[4]?.httpStatus).toBe(429)
-		expect(attempts[4]?.status).toBe('locked')
-		expect(attempts[4]?.body.code).toBe('OTP_LOCKED')
-		expect(attempts[4]?.body.error).toBe('Session locked')
-		expect(attempts[4]?.headers?.['Retry-After']).toBe('300')
+				const attempts = []
+
+				for (let attempt = 0; attempt < 5; attempt += 1) {
+					attempts.push(
+						await validateOtpChallengeRequest(
+							{
+								cedula: '12345678',
+								code: '000000',
+								route: '/api/otp/validate',
+								validationLimit: 5,
+								validationWindowMinutes: 5,
+							},
+							deps,
+						),
+					)
+				}
+
+				expect(permissiveAttempts).toBe(5)
+				expect(attempts.every((attempt) => attempt.httpStatus === 404)).toBe(true)
+				expect(attempts[0]?.headers?.['X-Hardening-Feature']).toBe('otp-hardening')
+				expect(attempts[0]?.headers?.['X-Hardening-Status']).toBe('disabled')
+				expect(events.length).toBe(5)
+				expect((events[0]?.[1] as Record<string, unknown>)?.feature_name).toBe(
+					'otp-hardening',
+				)
+				expect((events[0]?.[1] as Record<string, unknown>)?.status).toBe(
+					'disabled',
+				)
+				expect((events[0]?.[1] as Record<string, unknown>)?.source).toBe(
+					'otp-validate',
+				)
+				expect((events[0]?.[1] as Record<string, unknown>)?.route).toBe(
+					'/api/otp/validate',
+				)
+			} finally {
+				console.info = originalInfo
+			}
+		})
 	})
 })

--- a/tests/operational-hardening.test.ts
+++ b/tests/operational-hardening.test.ts
@@ -1,15 +1,155 @@
 import { describe, expect, it } from 'bun:test'
+import { NextRequest, NextResponse } from 'next/server'
+import {
+	evaluateHardeningFlag,
+	HARDENING_FLAG,
+	resolveHardeningFlag,
+} from '@/lib/hardeningPolicy'
 import {
 	CONSENT_ASSET_LIMITS,
 	getConsentSignatureAccessUrl,
 	loadConsentSignatureBuffer,
 } from '@/services/consentService'
 import {
+	buildExportMetadataHeaders,
+	EXPORT_FALLBACK_ROW_CAP,
 	EXPORT_RANGE_MAX_DAYS,
 	resolveBoundedExportRange,
+	resolveExportRange,
 } from '@/services/exportRangeService'
 
+const { handleUsersExport } = await import(
+	'@/app/api/admin/export/users/route'
+)
+const { handleConsentsExport } = await import(
+	'@/app/api/admin/export/consents/route'
+)
+
+function createAuthorizedExportDeps<TCsv extends { csv: string; rowCount: number }>(
+	exportResult: TCsv,
+) {
+	return {
+		verifyAdminTokenWithPermission: async () => ({
+			success: true as const,
+			uid: 'admin-uid',
+			email: 'admin@example.com',
+			role: 'admin' as const,
+			expiresAt: new Date(Date.now() + 60_000).toISOString(),
+			transport: 'bearer' as const,
+		}),
+		buildUsersCsvExport: async () => exportResult,
+		buildConsentsCsvExport: async () => exportResult,
+	}
+}
+
+async function withEnv<T>(
+	key: string,
+	value: string | undefined,
+	callback: () => Promise<T> | T,
+): Promise<T> {
+	const previousValue = process.env[key]
+
+	if (value === undefined) {
+		delete process.env[key]
+	} else {
+		process.env[key] = value
+	}
+
+	try {
+		return await callback()
+	} finally {
+		if (previousValue === undefined) {
+			delete process.env[key]
+		} else {
+			process.env[key] = previousValue
+		}
+	}
+}
+
 describe('operational hardening helpers', () => {
+	it('honors explicit true rollout flags', async () => {
+		await withEnv('OTP_HARDENING_ENABLED', 'true', () => {
+			const resolution = resolveHardeningFlag(HARDENING_FLAG.OTP_HARDENING)
+
+			expect(resolution.enabled).toBe(true)
+			expect(resolution.status).toBe('enabled')
+			expect(resolution.fallbackApplied).toBe(false)
+		})
+	})
+
+	it('defaults missing and malformed rollout flags to secure-on with deterministic warnings', async () => {
+		const originalWarn = console.warn
+		const warnings: unknown[][] = []
+		console.warn = (...args: unknown[]) => {
+			warnings.push(args)
+		}
+
+		try {
+			await withEnv('OTP_HARDENING_ENABLED', undefined, () => {
+				const resolution = resolveHardeningFlag(HARDENING_FLAG.OTP_HARDENING)
+
+				expect(resolution.enabled).toBe(true)
+				expect(resolution.status).toBe('defaulted')
+			})
+
+			await withEnv('OTP_HARDENING_ENABLED', 'banana', () => {
+				const resolution = resolveHardeningFlag(HARDENING_FLAG.OTP_HARDENING)
+
+				expect(resolution.enabled).toBe(true)
+				expect(resolution.status).toBe('defaulted')
+			})
+		} finally {
+			console.warn = originalWarn
+		}
+
+		expect(warnings.length).toBe(2)
+		expect((warnings[0]?.[1] as Record<string, unknown>)?.feature_name).toBe(
+			'otp-hardening',
+		)
+		expect((warnings[0]?.[1] as Record<string, unknown>)?.status).toBe(
+			'defaulted',
+		)
+		expect((warnings[1]?.[1] as Record<string, unknown>)?.feature_name).toBe(
+			'otp-hardening',
+		)
+		expect((warnings[1]?.[1] as Record<string, unknown>)?.status).toBe(
+			'defaulted',
+		)
+	})
+
+	it('emits deterministic policy telemetry markers', async () => {
+		const originalInfo = console.info
+		const events: unknown[][] = []
+		console.info = (...args: unknown[]) => {
+			events.push(args)
+		}
+
+		try {
+			await withEnv('EXPORT_BOUNDS_ENFORCED', 'false', () => {
+				const evaluation = evaluateHardeningFlag({
+					featureName: HARDENING_FLAG.EXPORT_BOUNDS,
+					source: 'admin-export-users',
+					route: '/api/admin/export/users',
+				})
+
+				expect(evaluation.event.feature_name).toBe('export-bounds')
+				expect(evaluation.event.status).toBe('disabled')
+				expect(evaluation.headers['X-Hardening-Feature']).toBe('export-bounds')
+				expect(evaluation.headers['X-Hardening-Status']).toBe('disabled')
+			})
+		} finally {
+			console.info = originalInfo
+		}
+
+		expect(events.length).toBe(1)
+		expect((events[0]?.[1] as Record<string, unknown>)?.feature_name).toBe(
+			'export-bounds',
+		)
+		expect((events[0]?.[1] as Record<string, unknown>)?.status).toBe(
+			'disabled',
+		)
+	})
+
 	it('rejects unbounded export ranges', () => {
 		let errorMessage = ''
 
@@ -17,6 +157,7 @@ describe('operational hardening helpers', () => {
 			resolveBoundedExportRange({
 				field: 'signedAt',
 				from: '2026-01-01',
+				source: 'admin-export-consents',
 			})
 		} catch (error) {
 			errorMessage = error instanceof Error ? error.message : 'unknown-error'
@@ -33,6 +174,7 @@ describe('operational hardening helpers', () => {
 				field: 'signedAt',
 				from: '2026-01-01',
 				to: '2026-02-01',
+				source: 'admin-export-consents',
 			})
 		} catch (error) {
 			errorMessage = error instanceof Error ? error.message : 'unknown-error'
@@ -48,12 +190,138 @@ describe('operational hardening helpers', () => {
 			field: 'createdAt',
 			from: '2026-01-01',
 			to: '2026-01-30',
+			source: 'admin-export-users',
 		})
 
 		expect(result.metadata.bounded).toBe(true)
 		expect(result.metadata.rejected).toBe(false)
 		expect(result.metadata.capped).toBe(false)
 		expect(result.metadata.dayCount).toBe(30)
+	})
+
+	it('bypasses export bounds and keeps observability headers when disabled', async () => {
+		await withEnv('EXPORT_BOUNDS_ENFORCED', 'false', () => {
+			const range = resolveExportRange({
+				field: 'signedAt',
+				from: '2026-01-01',
+				to: '2026-12-31',
+				source: 'admin-export-consents',
+				route: '/api/admin/export/consents',
+			})
+			const headers = {
+				...range.hardening.headers,
+				...buildExportMetadataHeaders(range.metadata, 42),
+			}
+
+			expect(range.hardening.status).toBe('disabled')
+			expect(range.metadata.dayCount).toBeGreaterThan(EXPORT_RANGE_MAX_DAYS)
+			expect(headers['X-Hardening-Feature']).toBe('export-bounds')
+			expect(headers['X-Hardening-Status']).toBe('disabled')
+			expect(headers['X-Export-Bounds']).toBe('enforced')
+			expect(headers['X-Export-Row-Cap']).toBe(String(EXPORT_FALLBACK_ROW_CAP))
+		})
+	})
+
+	it('returns 400 with hardening headers from /api/admin/export/users when enforced bounds reject the range', async () => {
+		await withEnv('EXPORT_BOUNDS_ENFORCED', 'true', async () => {
+			const response = await handleUsersExport(
+				new NextRequest(
+					'https://example.com/api/admin/export/users?from=2026-01-01&to=2026-12-31',
+				),
+				createAuthorizedExportDeps({
+					csv: 'uid,name\n123,Visitor',
+					rowCount: 1,
+				}),
+			)
+			const body = (await response.json()) as {
+				code?: string
+				error?: string
+			}
+
+			expect(response.status).toBe(400)
+			expect(body.code).toBe('EXPORT_RANGE_TOO_WIDE')
+			expect(body.error).toBe(
+				`El rango máximo permitido es de ${EXPORT_RANGE_MAX_DAYS} días.`,
+			)
+			expect(response.headers.get('X-Hardening-Policy')).toBe('hardening.policy')
+			expect(response.headers.get('X-Hardening-Feature')).toBe('export-bounds')
+			expect(response.headers.get('X-Hardening-Status')).toBe('enabled')
+		})
+	})
+
+	it('returns 200 with final headers from /api/admin/export/users when bounds are disabled', async () => {
+		await withEnv('EXPORT_BOUNDS_ENFORCED', 'false', async () => {
+			const response = await handleUsersExport(
+				new NextRequest(
+					'https://example.com/api/admin/export/users?from=2026-01-01&to=2026-12-31',
+				),
+				createAuthorizedExportDeps({
+					csv: 'uid,name\n123,Visitor',
+					rowCount: 1,
+				}),
+			)
+
+			expect(response.status).toBe(200)
+			expect(await response.text()).toContain('uid,name')
+			expect(response.headers.get('X-Hardening-Policy')).toBe('hardening.policy')
+			expect(response.headers.get('X-Hardening-Feature')).toBe('export-bounds')
+			expect(response.headers.get('X-Hardening-Status')).toBe('disabled')
+			expect(response.headers.get('X-Export-Bounds')).toBe('enforced')
+			expect(response.headers.get('X-Export-Row-Cap')).toBe(
+				String(EXPORT_FALLBACK_ROW_CAP),
+			)
+		})
+	})
+
+	it('returns 400 with hardening headers from /api/admin/export/consents when enforced bounds reject the range', async () => {
+		await withEnv('EXPORT_BOUNDS_ENFORCED', 'true', async () => {
+			const response = await handleConsentsExport(
+				new NextRequest(
+					'https://example.com/api/admin/export/consents?from=2026-01-01&to=2026-12-31',
+				),
+				createAuthorizedExportDeps({
+					csv: 'consecutivo\n1',
+					rowCount: 1,
+				}),
+			)
+			const body = (await response.json()) as {
+				code?: string
+				error?: string
+			}
+
+			expect(response.status).toBe(400)
+			expect(body.code).toBe('EXPORT_RANGE_TOO_WIDE')
+			expect(body.error).toBe(
+				`El rango máximo permitido es de ${EXPORT_RANGE_MAX_DAYS} días.`,
+			)
+			expect(response.headers.get('X-Hardening-Policy')).toBe('hardening.policy')
+			expect(response.headers.get('X-Hardening-Feature')).toBe('export-bounds')
+			expect(response.headers.get('X-Hardening-Status')).toBe('enabled')
+		})
+	})
+
+	it('returns 200 with final headers from /api/admin/export/consents when bounds are disabled', async () => {
+		await withEnv('EXPORT_BOUNDS_ENFORCED', 'false', async () => {
+			const response = await handleConsentsExport(
+				new NextRequest(
+					'https://example.com/api/admin/export/consents?from=2026-01-01&to=2026-12-31',
+				),
+				createAuthorizedExportDeps({
+					csv: 'consecutivo\n1',
+					rowCount: 1,
+				}),
+			)
+
+			expect(response.status).toBe(200)
+			expect(await response.text()).toContain('consecutivo')
+			expect(response.headers.get('X-Hardening-Policy')).toBe('hardening.policy')
+			expect(response.headers.get('X-Hardening-Feature')).toBe('export-bounds')
+			expect(response.headers.get('X-Hardening-Status')).toBe('disabled')
+			expect(response.headers.get('X-Export-Bounds')).toBe('enforced')
+			expect(response.headers.get('X-Export-Row-Cap')).toBe(
+				String(EXPORT_FALLBACK_ROW_CAP),
+			)
+		})
 	})
 
 	it('keeps legacy http signature urls accessible', async () => {

--- a/tests/seo-public.test.ts
+++ b/tests/seo-public.test.ts
@@ -4,36 +4,89 @@ import { NextRequest } from 'next/server'
 const { proxy } = await import('@/proxy')
 const { default: robots } = await import('@/app/robots')
 const { default: sitemap } = await import('@/app/sitemap')
+const { generateMetadata } = await import('@/app/(public)/layout')
+
+async function withEnv<T>(
+	key: string,
+	value: string | undefined,
+	callback: () => Promise<T> | T,
+): Promise<T> {
+	const previousValue = process.env[key]
+
+	if (value === undefined) {
+		delete process.env[key]
+	} else {
+		process.env[key] = value
+	}
+
+	try {
+		return await callback()
+	} finally {
+		if (previousValue === undefined) {
+			delete process.env[key]
+		} else {
+			process.env[key] = previousValue
+		}
+	}
+}
 
 describe('public seo boundary', () => {
 	it('applies noindex header to kiosk root without leaking to public pages', async () => {
-		const kioskResponse = await proxy(new NextRequest('https://example.com/'))
-		const publicResponse = await proxy(
-			new NextRequest('https://example.com/consentimiento-digital'),
-		)
+		await withEnv('PUBLIC_SEO_ENABLED', 'true', async () => {
+			const kioskResponse = await proxy(new NextRequest('https://example.com/'))
+			const publicResponse = await proxy(
+				new NextRequest('https://example.com/consentimiento-digital'),
+			)
 
-		expect(kioskResponse.headers.get('X-Robots-Tag')).toBe('noindex, nofollow')
-		expect(publicResponse.headers.get('X-Robots-Tag')).toBe(null)
+			expect(kioskResponse.headers.get('X-Robots-Tag')).toBe('noindex, nofollow')
+			expect(publicResponse.headers.get('X-Robots-Tag')).toBe(null)
+		})
 	})
 
-	it('publishes robots rules only for public urls', () => {
-		const manifest = robots()
-		const rules = Array.isArray(manifest.rules)
-			? manifest.rules[0]
-			: manifest.rules
+	it('publishes robots, sitemap, and metadata when public SEO is enabled', async () => {
+		await withEnv('PUBLIC_SEO_ENABLED', 'true', async () => {
+			const manifest = robots()
+			const rules = Array.isArray(manifest.rules)
+				? manifest.rules[0]
+				: manifest.rules
+			const entries = sitemap()
+			const metadata = generateMetadata()
+			const robotsMetadata = metadata.robots as {
+				index?: boolean
+				follow?: boolean
+			}
 
-		expect(rules?.allow).toContain('/consentimiento-digital')
-		expect(rules?.disallow).toContain('/admin/')
-		expect(rules?.disallow).toContain('/ingreso/')
-		expect(manifest.sitemap).toBe('https://www.jumpingpark.lat/sitemap.xml')
+			expect(rules?.allow).toContain('/consentimiento-digital')
+			expect(rules?.disallow).toContain('/admin/')
+			expect(rules?.disallow).toContain('/ingreso/')
+			expect(manifest.sitemap).toBe('https://www.jumpingpark.lat/sitemap.xml')
+			expect(entries.length).toBe(1)
+			expect(entries[0]?.url).toBe(
+				'https://www.jumpingpark.lat/consentimiento-digital',
+			)
+			expect(robotsMetadata.index).toBe(true)
+			expect(robotsMetadata.follow).toBe(true)
+		})
 	})
 
-	it('includes only public urls in sitemap', () => {
-		const entries = sitemap()
+	it('blocks robots, hides sitemap, and returns noindex metadata when SEO is disabled', async () => {
+		await withEnv('PUBLIC_SEO_ENABLED', 'false', async () => {
+			const manifest = robots()
+			const rules = Array.isArray(manifest.rules)
+				? manifest.rules[0]
+				: manifest.rules
+			const entries = sitemap()
+			const metadata = generateMetadata()
+			const robotsMetadata = metadata.robots as {
+				index?: boolean
+				follow?: boolean
+			}
 
-		expect(entries.length).toBe(1)
-		expect(entries[0]?.url).toBe(
-			'https://www.jumpingpark.lat/consentimiento-digital',
-		)
+			expect(rules?.disallow).toContain('/')
+			expect(manifest.sitemap).toBe(undefined)
+			expect(entries.length).toBe(0)
+			expect(robotsMetadata.index).toBe(false)
+			expect(robotsMetadata.follow).toBe(false)
+		})
 	})
 })


### PR DESCRIPTION
Closes #9

## Summary
- wire PUBLIC_SEO_ENABLED through shared hardening policy in robots, sitemap, and public metadata
- keep SEO behavior server-side and deterministic for enabled vs disabled states
- add OpenSpec public-seo spec and targeted tests for crawler and metadata outputs

## Testing
- bun run check:format
- bun run check:lint
- bun run check:types
- bun test tests/seo-public.test.ts