### PR TITLE
fix(consent): omit absent offlineSync in payload

### DIFF
--- a/src/services/consentService.ts
+++ b/src/services/consentService.ts
@@ -576,14 +576,14 @@ class ConsentService {
 			createdAt: now,
 			searchTokens,
 			adultNameLower: userProfile.fullName.toLowerCase(),
-			offlineSync: offlineSync
-				? {
-						dedupeKey: offlineSync.dedupeKey,
-						source: OFFLINE_IDEMPOTENCY_SOURCE.SERVER,
-						recordId: offlineSync.dedupeKey,
-						acknowledgedAt: now.toISOString(),
-					}
-				: undefined,
+			...(offlineSync && {
+				offlineSync: {
+					dedupeKey: offlineSync.dedupeKey,
+					source: OFFLINE_IDEMPOTENCY_SOURCE.SERVER,
+					recordId: offlineSync.dedupeKey,
+					acknowledgedAt: now.toISOString(),
+				},
+			}),
 		};
 	}
 

--- a/tests/consent-service.test.ts
+++ b/tests/consent-service.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'bun:test'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import {
+	consentService,
+	type CreateConsentInput,
+} from '@/services/consentService'
+import type { Minor, UserProfile } from '@/types/firestore'
+import { OFFLINE_IDEMPOTENCY_SOURCE } from '@/types/offline'
+
+type ConsentPayload = {
+	policyVersion: string
+	offlineSync?: {
+		dedupeKey: string
+		source: string
+		recordId: string
+		acknowledgedAt: string
+	}
+} & Record<string, unknown>
+
+type ConsentServicePayloadBuilder = {
+	buildConsentDocumentPayload: (
+		consentId: string,
+		consecutivo: number,
+		userProfile: UserProfile,
+		normalizedMinors: Minor[],
+		signaturePath: string,
+		ipAddress: string,
+		offlineSync?: CreateConsentInput['offlineSync'],
+	) => ConsentPayload
+}
+
+const payloadBuilder = consentService as unknown as ConsentServicePayloadBuilder
+
+const validMinors: Minor[] = []
+
+const validUserProfile: UserProfile = {
+	uid: '12345',
+	fullName: 'Ada Lovelace',
+	email: 'ada@example.com',
+	phone: '3001234567',
+	minors: validMinors,
+	createdAt: new Date('2026-05-16T12:00:00.000Z'),
+	updatedAt: new Date('2026-05-16T12:00:00.000Z'),
+}
+
+function buildPayload(offlineSync?: CreateConsentInput['offlineSync']): ConsentPayload {
+	return payloadBuilder.buildConsentDocumentPayload(
+		'consent-123',
+		1001,
+		validUserProfile,
+		validMinors,
+		'signatures/12345/example.png',
+		'127.0.0.1',
+		offlineSync,
+	)
+}
+
+describe('consent service payload builder', () => {
+	it('omits offlineSync entirely when offline replay metadata is absent', () => {
+		const payload = buildPayload()
+
+		expect('offlineSync' in payload).toBe(false)
+		expect(Object.prototype.hasOwnProperty.call(payload, 'offlineSync')).toBe(
+			false,
+		)
+		expect(payload.policyVersion).toBe('1.0')
+	})
+
+	it('preserves offlineSync for offline replay writes when metadata is present', () => {
+		const payload = buildPayload({
+			dedupeKey: 'dedupe-123',
+			policyVersion: 'v2',
+			signedAtLocal: '2026-05-16T12:00:00.000Z',
+		})
+
+		expect(payload.policyVersion).toBe('v2')
+		expect(payload.offlineSync?.dedupeKey).toBe('dedupe-123')
+		expect(payload.offlineSync?.source).toBe(
+			OFFLINE_IDEMPOTENCY_SOURCE.SERVER,
+		)
+		expect(payload.offlineSync?.recordId).toBe('dedupe-123')
+		expect(typeof payload.offlineSync?.acknowledgedAt).toBe('string')
+	})
+
+	it('keeps Firestore initialization strict without ignoreUndefinedProperties', () => {
+		const firebaseAdminSource = readFileSync(
+			join(process.cwd(), 'src/lib/firebaseAdmin.ts'),
+			'utf8',
+		)
+		const firebaseClientSource = readFileSync(
+			join(process.cwd(), 'src/lib/firebaseClient.ts'),
+			'utf8',
+		)
+
+		expect(firebaseAdminSource).not.toContain('ignoreUndefinedProperties')
+		expect(firebaseClientSource).not.toContain('ignoreUndefinedProperties')
+	})
+})


### PR DESCRIPTION
Closes #18

## Summary
- omit `offlineSync` from the Firestore consent payload when the online path does not provide replay metadata
- preserve `offlineSync` for offline replay writes and lock in regression coverage for both behaviors
- keep Firestore strict by asserting `ignoreUndefinedProperties` is not enabled globally

## Changes
| File | Change |
|------|--------|
| `src/services/consentService.ts` | Replaced the `offlineSync` ternary emission with omission semantics when metadata is absent |
| `tests/consent-service.test.ts` | Added focused regression coverage for absent/present `offlineSync` and strict Firestore config |

## Verification
- `bun test tests/consent-service.test.ts tests/consent-route.test.ts tests/offline-resilience.test.ts tests/block-e-offline-replay.test.ts`
- `bun run check:types`
- local production kiosk flow validated after the fix (`/api/consentimientos` returned `201`)
