### PR TITLE
fix(kiosk): seed signature canvas readback context

### DIFF
--- a/playwright/signature-canvas-warning.a11y.ts
+++ b/playwright/signature-canvas-warning.a11y.ts
@@ -1,0 +1,114 @@
+import { expect, test } from '@playwright/test'
+import { seedAuthenticatedKioskSession } from './helpers'
+
+test.describe('Signature canvas willReadFrequently fix', () => {
+	test('submits a drawn kiosk signature without the Canvas2D warning', async ({
+		page,
+	}) => {
+		test.setTimeout(120_000)
+
+		const willReadFrequentlyWarnings: string[] = []
+		let submittedPayload: Record<string, unknown> | null = null
+
+		page.on('console', (message) => {
+			const text = message.text()
+			if (
+				/willReadFrequently|Multiple readback operations using getImageData/i.test(
+					text,
+				)
+			) {
+				willReadFrequentlyWarnings.push(text)
+			}
+		})
+
+		await page.route('**/api/consentimientos', async (route) => {
+			submittedPayload = route.request().postDataJSON() as Record<string, unknown>
+
+			await route.fulfill({
+				status: 200,
+				contentType: 'application/json',
+				body: JSON.stringify({ consecutivo: 'SIG-001' }),
+			})
+		})
+
+		await seedAuthenticatedKioskSession(page)
+		await page.goto('/consentimiento')
+		await expect(page.getByText('Ada Lovelace')).toBeVisible()
+
+		await page.locator('#inlineFirstName').fill('Luna')
+		await page.locator('#inlineLastName').fill('Lopez')
+		await page.locator('#inlineBirthDate').fill('2018-05-12')
+		await page.locator('#inlineEps').fill('Sura')
+		await page.locator('#inlineIdNumber').fill('RC12345')
+		await page.getByRole('button', { name: /save/i }).click()
+
+		const canvas = page.locator('canvas.cursor-crosshair').first()
+		await expect(canvas).toBeVisible()
+
+		await canvas.evaluate((element) => {
+			const signatureCanvas = element as HTMLCanvasElement
+			const rect = signatureCanvas.getBoundingClientRect()
+			const points = [
+				{ x: 24, y: rect.height / 2 },
+				{ x: rect.width / 2, y: 28 },
+				{ x: rect.width - 24, y: rect.height - 28 },
+			]
+
+			const createMouseEvent = (
+				type: 'mousedown' | 'mousemove' | 'mouseup',
+				x: number,
+				y: number,
+				buttons: number,
+			) =>
+				new MouseEvent(type, {
+					bubbles: true,
+					cancelable: true,
+					composed: true,
+					button: 0,
+					buttons,
+					clientX: rect.left + x,
+					clientY: rect.top + y,
+				})
+
+			signatureCanvas.dispatchEvent(
+				createMouseEvent('mousedown', points[0].x, points[0].y, 1),
+			)
+
+			for (const point of points.slice(1)) {
+				signatureCanvas.dispatchEvent(
+					createMouseEvent('mousemove', point.x, point.y, 1),
+				)
+			}
+
+			document.dispatchEvent(
+				createMouseEvent(
+					'mouseup',
+					points[points.length - 1].x,
+					points[points.length - 1].y,
+					0,
+				),
+			)
+		})
+		await page.waitForTimeout(100)
+		expect(willReadFrequentlyWarnings).toEqual([])
+
+		await page.locator('#acceptedPolicy').check()
+
+		await Promise.all([
+			page.waitForRequest('**/api/consentimientos'),
+			page.waitForURL(/\/exito\?/),
+			page.locator('button[type="submit"]').click(),
+		])
+
+		await page.waitForTimeout(250)
+
+		expect(willReadFrequentlyWarnings).toEqual([])
+		if (!submittedPayload) {
+			throw new Error('Consent submission payload was not captured')
+		}
+
+		const signatureBase64 = submittedPayload!['signature']
+		expect(typeof signatureBase64).toBe('string')
+		expect(signatureBase64 as string).toContain('data:image/png;base64,')
+	})
+})

--- a/src/components/kiosk/SignaturePad.tsx
+++ b/src/components/kiosk/SignaturePad.tsx
@@ -8,8 +8,118 @@ import {
 	useRef,
 	useState,
 } from "react";
-import SignatureCanvas from "react-signature-canvas";
+import SignatureCanvas, {
+	type SignatureCanvasProps,
+} from "react-signature-canvas";
 import { useUISound } from "@/hooks";
+
+const getAlpha = (
+	imageData: Uint8ClampedArray,
+	imageWidth: number,
+	x: number,
+	y: number,
+): number => imageData[(imageWidth * y + x) * 4 + 3];
+
+const scanY = (
+	fromTop: boolean,
+	imageWidth: number,
+	imageHeight: number,
+	imageData: Uint8ClampedArray,
+): number | null => {
+	const offset = fromTop ? 1 : -1;
+	const firstRow = fromTop ? 0 : imageHeight - 1;
+
+	for (let y = firstRow; fromTop ? y < imageHeight : y > -1; y += offset) {
+		for (let x = 0; x < imageWidth; x += 1) {
+			if (getAlpha(imageData, imageWidth, x, y) > 0) {
+				return y;
+			}
+		}
+	}
+
+	return null;
+};
+
+const scanX = (
+	fromLeft: boolean,
+	imageWidth: number,
+	imageHeight: number,
+	imageData: Uint8ClampedArray,
+): number | null => {
+	const offset = fromLeft ? 1 : -1;
+	const firstColumn = fromLeft ? 0 : imageWidth - 1;
+
+	for (let x = firstColumn; fromLeft ? x < imageWidth : x > -1; x += offset) {
+		for (let y = 0; y < imageHeight; y += 1) {
+			if (getAlpha(imageData, imageWidth, x, y) > 0) {
+				return x;
+			}
+		}
+	}
+
+	return null;
+};
+
+const trimCanvasForSignature = (
+	sourceCanvas: HTMLCanvasElement,
+): HTMLCanvasElement => {
+	const copy = document.createElement("canvas");
+	copy.width = sourceCanvas.width;
+	copy.height = sourceCanvas.height;
+
+	const seededContext = copy.getContext("2d", { willReadFrequently: true });
+	if (!seededContext) {
+		return copy;
+	}
+
+	seededContext.drawImage(sourceCanvas, 0, 0);
+
+	const imageData = seededContext.getImageData(0, 0, copy.width, copy.height).data;
+	const top = scanY(true, copy.width, copy.height, imageData);
+	const bottom = scanY(false, copy.width, copy.height, imageData);
+	const left = scanX(true, copy.width, copy.height, imageData);
+	const right = scanX(false, copy.width, copy.height, imageData);
+
+	if (
+		top === null ||
+		bottom === null ||
+		left === null ||
+		right === null
+	) {
+		return copy;
+	}
+
+	const trimmedWidth = right - left + 1;
+	const trimmedHeight = bottom - top + 1;
+	const trimmedData = seededContext.getImageData(
+		left,
+		top,
+		trimmedWidth,
+		trimmedHeight,
+	);
+
+	copy.width = trimmedWidth;
+	copy.height = trimmedHeight;
+
+	copy
+		.getContext("2d", { willReadFrequently: true })
+		?.putImageData(trimmedData, 0, 0);
+
+	return copy;
+};
+
+class SignatureCanvasFixed extends SignatureCanvas {
+	constructor(props: SignatureCanvasProps) {
+		super(props);
+
+		const originalComponentDidMount = this.componentDidMount;
+
+		this.componentDidMount = () => {
+			this.getCanvas().getContext("2d", { willReadFrequently: true });
+			originalComponentDidMount?.();
+		};
+	}
+}
 
 /**
  * Calcula la altura óptima del canvas basándose en el ancho.
@@ -40,14 +150,21 @@ const SignaturePad = forwardRef<SignaturePadRef, SignaturePadProps>(
 		const containerRef = useRef<HTMLDivElement>(null);
 		const [canvasSize, setCanvasSize] = useState({ width: 500, height: 200 });
 
+		const getTrimmedSignatureCanvas = (): HTMLCanvasElement => {
+			if (!sigCanvas.current) {
+				return document.createElement("canvas");
+			}
+
+			return trimCanvasForSignature(sigCanvas.current.getCanvas());
+		};
+
 		// Hook de sonidos para feedback auditivo
 		const { playClick } = useUISound();
 
 		// Expose methods to parent
 		useImperativeHandle(ref, () => ({
 			isEmpty: () => sigCanvas.current?.isEmpty() ?? true,
-			getTrimmedCanvas: () =>
-				sigCanvas.current?.getTrimmedCanvas() as HTMLCanvasElement,
+			getTrimmedCanvas: getTrimmedSignatureCanvas,
 			/**
 			 * Retorna la firma como base64 PNG optimizado.
 			 * Usa getTrimmedCanvas() para eliminar espacios vacíos y reducir tamaño.
@@ -56,7 +173,7 @@ const SignaturePad = forwardRef<SignaturePadRef, SignaturePadProps>(
 			toDataURL: () => {
 				if (!sigCanvas.current) return "";
 				// Usar canvas recortado para eliminar espacios en blanco
-				const trimmedCanvas = sigCanvas.current.getTrimmedCanvas();
+				const trimmedCanvas = getTrimmedSignatureCanvas();
 				// PNG con calidad por defecto (PNG no soporta quality param pero el trim reduce significativamente el peso)
 				return trimmedCanvas.toDataURL("image/png");
 			},
@@ -137,7 +254,7 @@ const SignaturePad = forwardRef<SignaturePadRef, SignaturePadProps>(
 					focus-within:ring-4 focus-within:ring-blue-500/15"
 				ref={containerRef}
 			>
-				<SignatureCanvas
+				<SignatureCanvasFixed
 					ref={sigCanvas}
 					penColor="#1e3a5f"
 					canvasProps={{


### PR DESCRIPTION
Closes #19

## Summary
- seed the signature canvas 2D context with `willReadFrequently: true` before `signature_pad` initializes
- preserve the existing signature ref API and trimmed PNG export behavior
- add a Playwright regression that submits a drawn kiosk signature without the Canvas2D warning

## Changes
| File | Change |
|------|--------|
| `src/components/kiosk/SignaturePad.tsx` | Wrap the signature canvas initialization so the readback-friendly context is seeded before mount |
| `playwright/signature-canvas-warning.a11y.ts` | Add a browser regression that validates drawing/submission without the warning |

## Verification
- `bun run check:types`
- `bun run build`
- `bunx playwright test playwright/signature-canvas-warning.a11y.ts --config=playwright.config.ts`
