### PR TITLE
fix(admin): omit undefined audit details

### DIFF
--- a/src/services/adminAuditService.ts
+++ b/src/services/adminAuditService.ts
@@ -17,13 +17,18 @@ export interface AdminAuditWriteInput {
 export function buildAdminAuditEntry(
 	input: AdminAuditWriteInput,
 ): Omit<AdminAuditLog, "createdAt"> {
-	return {
+	const entry: Omit<AdminAuditLog, "createdAt"> = {
 		action: input.action,
 		actor: input.actor,
 		target: input.target,
 		request: input.request,
-		details: input.details,
 	};
+
+	if (typeof input.details !== "undefined") {
+		entry.details = input.details;
+	}
+
+	return entry;
 }
 
 export function buildAdminAuditActor(session: {

--- a/tests/admin-phase3-hardening.test.ts
+++ b/tests/admin-phase3-hardening.test.ts
@@ -225,5 +225,6 @@ describe('phase 3 admin contract hardening', () => {
 		expect(headers['X-Export-Source']).toBe('live')
 		expect(setCalls.length).toBe(1)
 		expect(setCalls[0]?.data.action).toBe('consent.delete')
+		expect(setCalls[0]?.data).not.toHaveProperty('details')
 	})
 })


### PR DESCRIPTION
## Summary
- prevent admin consent deletion from failing when the audit payload has no optional `details`
- omit undefined audit fields before writing the Firestore batch
- add a regression assertion for the consent delete audit path

## Changes
| File | Change |
|------|--------|
| `src/services/adminAuditService.ts` | Build audit entries without serializing `details` when it is absent |
| `tests/admin-phase3-hardening.test.ts` | Assert the audit batch payload omits `details` for consent deletion |

## Testing
- [x] `bun test tests/admin-phase3-hardening.test.ts`
- [x] `bun test tests/phase3-runtime-proof-gaps.test.ts`
- [ ] Manual testing in production

Closes #25