### PR TITLE
chore(seo): stabilize phase 0 repo and ci hygiene

### DIFF
--- a/.gga
+++ b/.gga
@@ -1,0 +1,10 @@
+# Gentleman Guardian Angel — jumping_park_app
+# Provider: OpenCode (suscripción opencode-go)
+# Model: deepseek-v4-flash
+PROVIDER="opencode:opencode-go/deepseek-v4-flash"
+
+FILE_PATTERNS="*.ts,*.tsx,*.js,*.jsx"
+EXCLUDE_PATTERNS="*.test.ts,*.spec.ts,*.test.tsx,*.spec.tsx,*.d.ts"
+RULES_FILE="AGENTS.md"
+STRICT_MODE="true"
+TIMEOUT=500

--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,7 @@ firebase-debug.log*
 firestore-debug.log*
 seo-network.log
 .playwright-mcp/
-.gga
+# .gga
 playwright-report/
 test-results/
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,7 +73,7 @@
 ## Biome
 - Defer to `biome.json` — no duplicate lint config in `.eslintrc` or inline.
 - Key rules: `noUnusedImports: error`, `noUnusedVariables: warn`, `useExhaustiveDependencies: warn`.
-- Run `bun biome check` pre-commit — blocked on `error` severity.
+- Run `bun run check` pre-commit — blocked on `error` severity.
 
 ## Commit Conventions
 - Conventional Commits: `type(scope): description` (e.g., `feat(kiosk): add session restore`).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,11 +9,77 @@
 - Keep TypeScript strict.
 - Do not introduce `any`.
 - Reuse shared types and schemas.
+- No `as` casts — prefer type guards or Zod `.parse()`.
+- Colocate Zod schemas with the domain they validate (`src/lib/schemas/`).
+
+## Zod
+- Schemas in `src/lib/schemas/` — shared between client and server.
+- Never use `z.any()` — always narrow to the expected shape.
+- Prefer `.parse()` over `.safeParse()` when the caller must handle the error.
+- One schema file per domain: auth, visitor, consent, crud, legalContent.
 
 ## Next.js / React
 - Keep route handlers thin and service-driven.
 - Prefer server-safe configuration handling.
 - Preserve accessibility behavior in kiosk/admin flows.
+- Default to Server Components — `"use client"` only at leaf boundaries.
+- No `useMemo`/`useCallback` boilerplate (React 19 Compiler).
+- Validate API route input with Zod at the top of each handler.
+
+## Tailwind v4
+- Merge classes with `cn()` from `@/lib/utils` (clsx + tailwind-merge).
+- Import Tailwind via `@import "tailwindcss"` in `globals.css` — v4 syntax.
+- No inline `style={}` when Tailwind utilities cover the same effect.
+- Design tokens live as CSS variables in `globals.css`.
+
+## Zustand
+- One store per domain boundary (`useKioskStore`).
+- All mutations go through store actions — never mutate state outside.
+- Use `set((state) => ({ ... }))` for derived updates.
+
+## SWR
+- Derive stable keys from route + params — no anonymous inline strings.
+- Call `mutate(key)` after write operations to invalidate caches.
+- Prefer `useSWR` over bare `fetch()` — dedup, revalidation, error boundary.
+
+## Firebase
+- Client SDK (`firebase/app`, `firebase/auth`, `firebase/firestore`): `"use client"` modules only.
+- Admin SDK (`firebase-admin`): server routes and scripts only — never in client bundles.
+- `NEXT_PUBLIC_` prefix only for client-safe config keys.
+- Never hardcode credentials — all values from environment variables.
+
+## react-hook-form
+- Always pair `useForm` with `zodResolver(schema)` for type-safe validation.
+- Form schemas must match API-side Zod schemas — no drift.
+- Use `useFieldArray` for dynamic lists — no manual index management.
+
+## framer-motion
+- Motion components are client-only — wrap in `"use client"`.
+- Use `whileInView` with `once: true` for scroll-triggered reveals.
+- Respect `prefers-reduced-motion` — provide a static fallback.
+- Use `AnimatePresence` for enter/exit transitions on conditional rendering.
+
+## Resend
+- Templates live in `src/components/emails/` — isolated from app logic.
+- Never embed secrets, API keys, or tokenized URLs in templates.
+- One Resend singleton per process (`src/services/emailService.ts`).
+
+## Playwright
+- Tests in `playwright/` with `*.a11y.ts` naming — run via `bun test`.
+- Every page interaction test includes an Axe check (`new AxeBuilder({ page }).analyze()`).
+- Locator-based waits only (`toBeVisible`, `toBeHidden`) — no `page.waitForTimeout()`.
+- Test isolation: each test seeds its own state, no cross-test dependencies.
+
+## Biome
+- Defer to `biome.json` — no duplicate lint config in `.eslintrc` or inline.
+- Key rules: `noUnusedImports: error`, `noUnusedVariables: warn`, `useExhaustiveDependencies: warn`.
+- Run `bun biome check` pre-commit — blocked on `error` severity.
+
+## Commit Conventions
+- Conventional Commits: `type(scope): description` (e.g., `feat(kiosk): add session restore`).
+- Types: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `chore`, `ci`.
+- English, lowercase, imperative mood.
+- One logical work unit per commit.
 
 ## Repository Hygiene
 - Do not commit secrets or local-only artifacts.

--- a/lighthouserc.json
+++ b/lighthouserc.json
@@ -5,7 +5,7 @@
       "startServerCommand": "bun run start -- --hostname 127.0.0.1 --port 3000",
       "startServerReadyPattern": "Ready in",
       "url": [
-        "http://127.0.0.1:3000/"
+        "http://127.0.0.1:3000/consentimiento-digital"
       ]
     },
     "assert": {

--- a/src/components/kiosk/SignaturePad.tsx
+++ b/src/components/kiosk/SignaturePad.tsx
@@ -74,18 +74,18 @@ const trimCanvasForSignature = (
 
 	seededContext.drawImage(sourceCanvas, 0, 0);
 
-	const imageData = seededContext.getImageData(0, 0, copy.width, copy.height).data;
+	const imageData = seededContext.getImageData(
+		0,
+		0,
+		copy.width,
+		copy.height,
+	).data;
 	const top = scanY(true, copy.width, copy.height, imageData);
 	const bottom = scanY(false, copy.width, copy.height, imageData);
 	const left = scanX(true, copy.width, copy.height, imageData);
 	const right = scanX(false, copy.width, copy.height, imageData);
 
-	if (
-		top === null ||
-		bottom === null ||
-		left === null ||
-		right === null
-	) {
+	if (top === null || bottom === null || left === null || right === null) {
 		return copy;
 	}
 

--- a/tests/admin-phase3-hardening.test.ts
+++ b/tests/admin-phase3-hardening.test.ts
@@ -224,7 +224,12 @@ describe('phase 3 admin contract hardening', () => {
 		expect(headers['X-Export-Generated-At']).toBe('2026-04-29T00:00:00.000Z')
 		expect(headers['X-Export-Source']).toBe('live')
 		expect(setCalls.length).toBe(1)
-		expect(setCalls[0]?.data.action).toBe('consent.delete')
-		expect(setCalls[0]?.data).not.toHaveProperty('details')
+		const firstAuditWrite = setCalls[0]
+		if (!firstAuditWrite) {
+			throw new Error('Expected admin audit batch write')
+		}
+
+		expect(firstAuditWrite.data.action).toBe('consent.delete')
+		expect(Object.hasOwn(firstAuditWrite.data, 'details')).toBe(false)
 	})
 })

--- a/tests/lighthouse-ci-integration.test.ts
+++ b/tests/lighthouse-ci-integration.test.ts
@@ -66,7 +66,9 @@ describe('lighthouse ci integration slice', () => {
 			'bun run start -- --hostname 127.0.0.1 --port 3000',
 		)
 		expect(config.ci?.collect?.startServerReadyPattern).toBe('Ready in')
-		expect(config.ci?.collect?.url).toEqual(['http://127.0.0.1:3000/'])
+		expect(config.ci?.collect?.url).toEqual([
+			'http://127.0.0.1:3000/consentimiento-digital',
+		])
 		expect(config.ci?.upload?.target).toBe('temporary-public-storage')
 	})
 

--- a/tests/phase4-production-artifacts.test.ts
+++ b/tests/phase4-production-artifacts.test.ts
@@ -251,11 +251,12 @@ describe('phase 4 docs and ci parity', () => {
 		expect(adminCostChecklist).toContain('Si algun query exige un indice nuevo o distinto, no habilitar el flag: primero actualizar IaC y volver a validar contra emulator/query logs.')
 	})
 
-	it('keeps CI focused on reproducible static gates plus artifact parity proof before build verification', () => {
+	it('keeps CI focused on reproducible static gates and tests before build verification', () => {
 		const workflow = readProjectFile('.github/workflows/ci.yml')
 
 		expect(workflow).toContain('run: bun run check')
-		expect(workflow).toContain('name: Run production-readiness artifact parity proof')
-		expect(workflow).toContain('run: bun test tests/phase4-production-artifacts.test.ts')
+		expect(workflow).toContain('name: Run tests')
+		expect(workflow).toContain('run: bun test')
+		expect(workflow).toContain('needs:\n      - quality')
 	})
 })


### PR DESCRIPTION
## Summary
- Preserves the Phase 0 repo/CI hygiene slice for the SEO/performance audit.
- Adds tracked GGA review configuration and expands repo agent rules.
- Fixes baseline CI blockers: unsupported Bun matcher typing, SignaturePad formatting, and Lighthouse CI parity expectations.

## Changes
- Track `.gga` and allow it through `.gitignore`.
- Expand `AGENTS.md` with current project conventions.
- Point Lighthouse CI at `/consentimiento-digital`.
- Replace unsupported `toHaveProperty` matcher usage in the admin hardening test.
- Apply the pre-existing SignaturePad format fix required for `bun run check`.

## Testing
- [x] `bun test tests/lighthouse-ci-integration.test.ts tests/phase4-production-artifacts.test.ts`
- [x] `bun run check`
- [x] `bun test`

## SDD
- Change: `seo-performance-ai-visibility-audit`
- Phase: 0 repo/CI hygiene slice
- Strategy: stacked-to-main

Follow-up PRs will preserve the public metadata/OG and landing redesign slices separately.