### PR TITLE
feat(seo): preserve public metadata and og slice

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,6 +28,7 @@ OTP_LOCKOUT_MINUTES=15
 OTP_HARDENING_ENABLED=true
 EXPORT_BOUNDS_ENFORCED=true
 PUBLIC_SEO_ENABLED=false
+NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION=
 
 # Flag changes require a local server restart.
 # On Vercel/preview/production, update env vars and redeploy.

--- a/src/app/(public)/layout.tsx
+++ b/src/app/(public)/layout.tsx
@@ -1,10 +1,16 @@
 import type { Metadata } from "next";
-import { buildPublicRobotsMetadata, buildSiteVerification } from "@/lib/seo";
+import {
+	buildPublicSeoPolicy,
+	buildRobotsMetadataFromPolicy,
+	buildSiteVerification,
+} from "@/lib/seo";
 
 export function generateMetadata(): Metadata {
+	const publicSeoPolicy = buildPublicSeoPolicy();
+
 	return {
-		robots: buildPublicRobotsMetadata(),
-		verification: buildSiteVerification(),
+		robots: buildRobotsMetadataFromPolicy(publicSeoPolicy),
+		verification: buildSiteVerification(publicSeoPolicy),
 	};
 }
 

--- a/src/app/(public)/layout.tsx
+++ b/src/app/(public)/layout.tsx
@@ -1,9 +1,10 @@
 import type { Metadata } from "next";
-import { buildPublicRobotsMetadata } from "@/lib/seo";
+import { buildPublicRobotsMetadata, buildSiteVerification } from "@/lib/seo";
 
 export function generateMetadata(): Metadata {
 	return {
 		robots: buildPublicRobotsMetadata(),
+		verification: buildSiteVerification(),
 	};
 }
 

--- a/src/app/(public)/opengraph-image.tsx
+++ b/src/app/(public)/opengraph-image.tsx
@@ -1,11 +1,12 @@
 import { ImageResponse } from "next/og";
+import { CONSENTIMIENTO_DIGITAL_OPEN_GRAPH_ALT } from "@/lib/consentimientoDigitalSeo";
 import {
-	CONSENTIMIENTO_DIGITAL_OPEN_GRAPH_ALT,
+	APP_NAME,
 	CONSENTIMIENTO_DIGITAL_PAGE_PATH,
-} from "@/lib/consentimientoDigitalSeo";
-import { APP_NAME } from "@/lib/seo";
+	createCanonicalUrl,
+} from "@/lib/seo";
 
-const PAGE_URL = `https://www.jumpingpark.lat${CONSENTIMIENTO_DIGITAL_PAGE_PATH}`;
+const PAGE_URL = createCanonicalUrl(CONSENTIMIENTO_DIGITAL_PAGE_PATH);
 
 export const alt = CONSENTIMIENTO_DIGITAL_OPEN_GRAPH_ALT;
 export const size = {

--- a/src/app/(public)/opengraph-image.tsx
+++ b/src/app/(public)/opengraph-image.tsx
@@ -1,0 +1,122 @@
+import { ImageResponse } from 'next/og'
+import { APP_NAME } from '@/lib/seo'
+import {
+	CONSENTIMIENTO_DIGITAL_OPEN_GRAPH_ALT,
+	CONSENTIMIENTO_DIGITAL_PAGE_PATH,
+} from '@/lib/consentimientoDigitalSeo'
+
+const PAGE_URL = `https://www.jumpingpark.lat${CONSENTIMIENTO_DIGITAL_PAGE_PATH}`
+
+export const alt = CONSENTIMIENTO_DIGITAL_OPEN_GRAPH_ALT
+export const size = {
+	height: 630,
+	width: 1200,
+} as const
+export const contentType = 'image/png'
+
+export default function OpenGraphImage() {
+	return new ImageResponse(
+		(
+			<div
+				style={{
+					alignItems: 'stretch',
+					background:
+						'linear-gradient(135deg, #09090b 0%, #18181b 45%, #052e2b 100%)',
+					color: '#f8fafc',
+					display: 'flex',
+					height: '100%',
+					padding: '56px 64px',
+					position: 'relative',
+					width: '100%',
+				}}
+			>
+				<div
+					style={{
+						background:
+							'radial-gradient(circle at top left, rgba(52, 211, 153, 0.38), transparent 38%), radial-gradient(circle at top right, rgba(168, 85, 247, 0.28), transparent 28%)',
+						inset: 0,
+						position: 'absolute',
+					}}
+				/>
+				<div
+					style={{
+						alignItems: 'flex-start',
+						display: 'flex',
+						flexDirection: 'column',
+						gap: '22px',
+						justifyContent: 'space-between',
+						position: 'relative',
+						width: '100%',
+					}}
+				>
+					<div
+						style={{
+							border: '1px solid rgba(255,255,255,0.16)',
+							borderRadius: '999px',
+							color: '#a7f3d0',
+							display: 'flex',
+							fontSize: 22,
+							fontWeight: 700,
+							letterSpacing: '0.18em',
+							padding: '14px 22px',
+							textTransform: 'uppercase',
+						}}
+					>
+						{APP_NAME}
+					</div>
+					<div
+						style={{
+							display: 'flex',
+							flexDirection: 'column',
+							gap: '18px',
+							maxWidth: 880,
+						}}
+					>
+						<div
+							style={{
+								fontSize: 76,
+								fontWeight: 900,
+								lineHeight: 1.05,
+							}}
+						>
+							Consentimiento digital claro, rapido y listo antes de saltar.
+						</div>
+					<div
+						style={{
+							color: '#d4d4d8',
+							fontSize: 34,
+							lineHeight: 1.35,
+						}}
+						>
+							Validacion OTP, firma segura y experiencia premium para adultos y menores.
+						</div>
+					</div>
+					<div
+						style={{
+							alignItems: 'center',
+							display: 'flex',
+							gap: '18px',
+						}}
+					>
+						<div
+							style={{
+								background: 'rgba(255,255,255,0.08)',
+								border: '1px solid rgba(255,255,255,0.12)',
+								borderRadius: '26px',
+								color: '#e4e4e7',
+								display: 'flex',
+								fontSize: 24,
+								padding: '14px 20px',
+							}}
+						>
+							{PAGE_URL}
+						</div>
+					</div>
+				</div>
+			</div>
+		),
+		{
+			...size,
+		},
+	)
+}

--- a/src/app/(public)/opengraph-image.tsx
+++ b/src/app/(public)/opengraph-image.tsx
@@ -1,122 +1,121 @@
-import { ImageResponse } from 'next/og'
-import { APP_NAME } from '@/lib/seo'
+import { ImageResponse } from "next/og";
 import {
 	CONSENTIMIENTO_DIGITAL_OPEN_GRAPH_ALT,
 	CONSENTIMIENTO_DIGITAL_PAGE_PATH,
-} from '@/lib/consentimientoDigitalSeo'
+} from "@/lib/consentimientoDigitalSeo";
+import { APP_NAME } from "@/lib/seo";
 
-const PAGE_URL = `https://www.jumpingpark.lat${CONSENTIMIENTO_DIGITAL_PAGE_PATH}`
+const PAGE_URL = `https://www.jumpingpark.lat${CONSENTIMIENTO_DIGITAL_PAGE_PATH}`;
 
-export const alt = CONSENTIMIENTO_DIGITAL_OPEN_GRAPH_ALT
+export const alt = CONSENTIMIENTO_DIGITAL_OPEN_GRAPH_ALT;
 export const size = {
 	height: 630,
 	width: 1200,
-} as const
-export const contentType = 'image/png'
+} as const;
+export const contentType = "image/png";
 
 export default function OpenGraphImage() {
 	return new ImageResponse(
-		(
+		<div
+			style={{
+				alignItems: "stretch",
+				background:
+					"linear-gradient(135deg, #09090b 0%, #18181b 45%, #052e2b 100%)",
+				color: "#f8fafc",
+				display: "flex",
+				height: "100%",
+				padding: "56px 64px",
+				position: "relative",
+				width: "100%",
+			}}
+		>
 			<div
 				style={{
-					alignItems: 'stretch',
 					background:
-						'linear-gradient(135deg, #09090b 0%, #18181b 45%, #052e2b 100%)',
-					color: '#f8fafc',
-					display: 'flex',
-					height: '100%',
-					padding: '56px 64px',
-					position: 'relative',
-					width: '100%',
+						"radial-gradient(circle at top left, rgba(52, 211, 153, 0.38), transparent 38%), radial-gradient(circle at top right, rgba(168, 85, 247, 0.28), transparent 28%)",
+					inset: 0,
+					position: "absolute",
+				}}
+			/>
+			<div
+				style={{
+					alignItems: "flex-start",
+					display: "flex",
+					flexDirection: "column",
+					gap: "22px",
+					justifyContent: "space-between",
+					position: "relative",
+					width: "100%",
 				}}
 			>
 				<div
 					style={{
-						background:
-							'radial-gradient(circle at top left, rgba(52, 211, 153, 0.38), transparent 38%), radial-gradient(circle at top right, rgba(168, 85, 247, 0.28), transparent 28%)',
-						inset: 0,
-						position: 'absolute',
+						border: "1px solid rgba(255,255,255,0.16)",
+						borderRadius: "999px",
+						color: "#a7f3d0",
+						display: "flex",
+						fontSize: 22,
+						fontWeight: 700,
+						letterSpacing: "0.18em",
+						padding: "14px 22px",
+						textTransform: "uppercase",
 					}}
-				/>
+				>
+					{APP_NAME}
+				</div>
 				<div
 					style={{
-						alignItems: 'flex-start',
-						display: 'flex',
-						flexDirection: 'column',
-						gap: '22px',
-						justifyContent: 'space-between',
-						position: 'relative',
-						width: '100%',
+						display: "flex",
+						flexDirection: "column",
+						gap: "18px",
+						maxWidth: 880,
 					}}
 				>
 					<div
 						style={{
-							border: '1px solid rgba(255,255,255,0.16)',
-							borderRadius: '999px',
-							color: '#a7f3d0',
-							display: 'flex',
-							fontSize: 22,
-							fontWeight: 700,
-							letterSpacing: '0.18em',
-							padding: '14px 22px',
-							textTransform: 'uppercase',
+							fontSize: 76,
+							fontWeight: 900,
+							lineHeight: 1.05,
 						}}
 					>
-						{APP_NAME}
+						Consentimiento digital claro, rapido y listo antes de saltar.
 					</div>
 					<div
 						style={{
-							display: 'flex',
-							flexDirection: 'column',
-							gap: '18px',
-							maxWidth: 880,
-						}}
-					>
-						<div
-							style={{
-								fontSize: 76,
-								fontWeight: 900,
-								lineHeight: 1.05,
-							}}
-						>
-							Consentimiento digital claro, rapido y listo antes de saltar.
-						</div>
-					<div
-						style={{
-							color: '#d4d4d8',
+							color: "#d4d4d8",
 							fontSize: 34,
 							lineHeight: 1.35,
 						}}
-						>
-							Validacion OTP, firma segura y experiencia premium para adultos y menores.
-						</div>
+					>
+						Validacion OTP, firma segura y experiencia premium para adultos y
+						menores.
 					</div>
+				</div>
+				<div
+					style={{
+						alignItems: "center",
+						display: "flex",
+						gap: "18px",
+					}}
+				>
 					<div
 						style={{
-							alignItems: 'center',
-							display: 'flex',
-							gap: '18px',
+							background: "rgba(255,255,255,0.08)",
+							border: "1px solid rgba(255,255,255,0.12)",
+							borderRadius: "26px",
+							color: "#e4e4e7",
+							display: "flex",
+							fontSize: 24,
+							padding: "14px 20px",
 						}}
 					>
-						<div
-							style={{
-								background: 'rgba(255,255,255,0.08)',
-								border: '1px solid rgba(255,255,255,0.12)',
-								borderRadius: '26px',
-								color: '#e4e4e7',
-								display: 'flex',
-								fontSize: 24,
-								padding: '14px 20px',
-							}}
-						>
-							{PAGE_URL}
-						</div>
+						{PAGE_URL}
 					</div>
 				</div>
 			</div>
-		),
+		</div>,
 		{
 			...size,
 		},
-	)
+	);
 }

--- a/src/lib/consentimientoDigitalSeo.ts
+++ b/src/lib/consentimientoDigitalSeo.ts
@@ -1,17 +1,20 @@
-import type { Metadata } from 'next'
-import { APP_NAME, buildPageFreshnessMetadata, createCanonicalUrl } from '@/lib/seo'
+import type { Metadata } from "next";
+import {
+	APP_NAME,
+	buildPageFreshnessMetadata,
+	createCanonicalUrl,
+} from "@/lib/seo";
 
-export const CONSENTIMIENTO_DIGITAL_PAGE_PATH = '/consentimiento-digital'
+export const CONSENTIMIENTO_DIGITAL_PAGE_PATH = "/consentimiento-digital";
 export const CONSENTIMIENTO_DIGITAL_PAGE_TITLE =
-	'Consentimiento digital para visitantes'
+	"Consentimiento digital para visitantes";
 export const CONSENTIMIENTO_DIGITAL_PAGE_DESCRIPTION =
-	'Conoce como funciona el consentimiento digital de Jumping Park antes de llegar al parque: registro agil, validacion por OTP y firma segura para adultos y menores.'
-export const CONSENTIMIENTO_DIGITAL_OPEN_GRAPH_IMAGE_PATH = '/opengraph-image'
+	"Conoce como funciona el consentimiento digital de Jumping Park antes de llegar al parque: registro agil, validacion por OTP y firma segura para adultos y menores.";
+export const CONSENTIMIENTO_DIGITAL_OPEN_GRAPH_IMAGE_PATH = "/opengraph-image";
 export const CONSENTIMIENTO_DIGITAL_OPEN_GRAPH_IMAGE_URL = createCanonicalUrl(
 	CONSENTIMIENTO_DIGITAL_OPEN_GRAPH_IMAGE_PATH,
-)
-export const CONSENTIMIENTO_DIGITAL_OPEN_GRAPH_ALT =
-	`${APP_NAME} | Consentimiento digital premium`
+);
+export const CONSENTIMIENTO_DIGITAL_OPEN_GRAPH_ALT = `${APP_NAME} | Consentimiento digital premium`;
 
 export function buildConsentimientoDigitalMetadata(): Metadata {
 	return {
@@ -24,7 +27,7 @@ export function buildConsentimientoDigitalMetadata(): Metadata {
 			title: `${CONSENTIMIENTO_DIGITAL_PAGE_TITLE} | ${APP_NAME}`,
 			description: CONSENTIMIENTO_DIGITAL_PAGE_DESCRIPTION,
 			url: createCanonicalUrl(CONSENTIMIENTO_DIGITAL_PAGE_PATH),
-			type: 'article',
+			type: "article",
 			...buildPageFreshnessMetadata(),
 			images: [
 				{
@@ -36,10 +39,10 @@ export function buildConsentimientoDigitalMetadata(): Metadata {
 			],
 		},
 		twitter: {
-			card: 'summary_large_image',
+			card: "summary_large_image",
 			title: `${CONSENTIMIENTO_DIGITAL_PAGE_TITLE} | ${APP_NAME}`,
 			description: CONSENTIMIENTO_DIGITAL_PAGE_DESCRIPTION,
 			images: [CONSENTIMIENTO_DIGITAL_OPEN_GRAPH_IMAGE_URL],
 		},
-	}
+	};
 }

--- a/src/lib/consentimientoDigitalSeo.ts
+++ b/src/lib/consentimientoDigitalSeo.ts
@@ -1,0 +1,45 @@
+import type { Metadata } from 'next'
+import { APP_NAME, buildPageFreshnessMetadata, createCanonicalUrl } from '@/lib/seo'
+
+export const CONSENTIMIENTO_DIGITAL_PAGE_PATH = '/consentimiento-digital'
+export const CONSENTIMIENTO_DIGITAL_PAGE_TITLE =
+	'Consentimiento digital para visitantes'
+export const CONSENTIMIENTO_DIGITAL_PAGE_DESCRIPTION =
+	'Conoce como funciona el consentimiento digital de Jumping Park antes de llegar al parque: registro agil, validacion por OTP y firma segura para adultos y menores.'
+export const CONSENTIMIENTO_DIGITAL_OPEN_GRAPH_IMAGE_PATH = '/opengraph-image'
+export const CONSENTIMIENTO_DIGITAL_OPEN_GRAPH_IMAGE_URL = createCanonicalUrl(
+	CONSENTIMIENTO_DIGITAL_OPEN_GRAPH_IMAGE_PATH,
+)
+export const CONSENTIMIENTO_DIGITAL_OPEN_GRAPH_ALT =
+	`${APP_NAME} | Consentimiento digital premium`
+
+export function buildConsentimientoDigitalMetadata(): Metadata {
+	return {
+		title: CONSENTIMIENTO_DIGITAL_PAGE_TITLE,
+		description: CONSENTIMIENTO_DIGITAL_PAGE_DESCRIPTION,
+		alternates: {
+			canonical: CONSENTIMIENTO_DIGITAL_PAGE_PATH,
+		},
+		openGraph: {
+			title: `${CONSENTIMIENTO_DIGITAL_PAGE_TITLE} | ${APP_NAME}`,
+			description: CONSENTIMIENTO_DIGITAL_PAGE_DESCRIPTION,
+			url: createCanonicalUrl(CONSENTIMIENTO_DIGITAL_PAGE_PATH),
+			type: 'article',
+			...buildPageFreshnessMetadata(),
+			images: [
+				{
+					url: CONSENTIMIENTO_DIGITAL_OPEN_GRAPH_IMAGE_URL,
+					width: 1200,
+					height: 630,
+					alt: CONSENTIMIENTO_DIGITAL_OPEN_GRAPH_ALT,
+				},
+			],
+		},
+		twitter: {
+			card: 'summary_large_image',
+			title: `${CONSENTIMIENTO_DIGITAL_PAGE_TITLE} | ${APP_NAME}`,
+			description: CONSENTIMIENTO_DIGITAL_PAGE_DESCRIPTION,
+			images: [CONSENTIMIENTO_DIGITAL_OPEN_GRAPH_IMAGE_URL],
+		},
+	}
+}

--- a/src/lib/consentimientoDigitalSeo.ts
+++ b/src/lib/consentimientoDigitalSeo.ts
@@ -2,14 +2,12 @@ import type { Metadata } from "next";
 import {
 	APP_NAME,
 	buildPageFreshnessMetadata,
+	CONSENTIMIENTO_DIGITAL_PAGE_DESCRIPTION,
+	CONSENTIMIENTO_DIGITAL_PAGE_PATH,
+	CONSENTIMIENTO_DIGITAL_PAGE_TITLE,
 	createCanonicalUrl,
 } from "@/lib/seo";
 
-export const CONSENTIMIENTO_DIGITAL_PAGE_PATH = "/consentimiento-digital";
-export const CONSENTIMIENTO_DIGITAL_PAGE_TITLE =
-	"Consentimiento digital para visitantes";
-export const CONSENTIMIENTO_DIGITAL_PAGE_DESCRIPTION =
-	"Conoce como funciona el consentimiento digital de Jumping Park antes de llegar al parque: registro agil, validacion por OTP y firma segura para adultos y menores.";
 export const CONSENTIMIENTO_DIGITAL_OPEN_GRAPH_IMAGE_PATH = "/opengraph-image";
 export const CONSENTIMIENTO_DIGITAL_OPEN_GRAPH_IMAGE_URL = createCanonicalUrl(
 	CONSENTIMIENTO_DIGITAL_OPEN_GRAPH_IMAGE_PATH,

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -52,6 +52,36 @@ export const INDEXABLE_ROBOTS: NonNullable<Metadata["robots"]> = {
 	},
 };
 
+export const FRESHNESS_DATE = "2026-05-17T00:00:00.000Z";
+
+export interface FaqItem {
+	answer: string;
+	question: string;
+}
+
+export const CONSENTIMIENTO_DIGITAL_FAQ_ENTRIES = [
+	{
+		answer:
+			"Documento del visitante, correo del responsable y unos minutos para validar el OTP y firmar.",
+		question: "Que necesito tener listo antes de llegar?",
+	},
+	{
+		answer:
+			"El flujo solicita al adulto responsable, relaciona al menor y deja el consentimiento claro para el equipo.",
+		question: "Que pasa si quien va a ingresar es menor de edad?",
+	},
+	{
+		answer:
+			"Si. El consentimiento queda capturado digitalmente y disponible para soporte operativo y consulta administrativa.",
+		question: "La firma digital reemplaza el formato fisico?",
+	},
+	{
+		answer:
+			"Reduce filas, evita repetir datos en recepcion y permite llegar al parque con el proceso mucho mas claro.",
+		question: "En que mejora esto mi ingreso al parque?",
+	},
+] as const satisfies readonly FaqItem[];
+
 export function createCanonicalUrl(pathname = "/"): string {
 	return new URL(pathname, APP_URL).toString();
 }
@@ -64,6 +94,39 @@ export function buildPublicRobotsMetadata(): NonNullable<Metadata["robots"]> {
 	});
 
 	return policy.enabled ? INDEXABLE_ROBOTS : NON_INDEXABLE_ROBOTS;
+}
+
+export function buildSiteVerification(): NonNullable<Metadata["verification"]> {
+	const policy = evaluateHardeningFlag({
+		featureName: HARDENING_FLAG.PUBLIC_SEO,
+		source: "public-metadata",
+		route: "/(public)",
+		details: {
+			metadata: "verification",
+		},
+	});
+
+	if (!policy.enabled) {
+		return {};
+	}
+
+	const googleCode = process.env.NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION?.trim();
+
+	if (!googleCode) {
+		return {};
+	}
+
+	return {
+		google: googleCode,
+	};
+}
+
+export function buildPageFreshnessMetadata(lastModified?: string): {
+	modifiedTime: string;
+} {
+	return {
+		modifiedTime: lastModified ?? FRESHNESS_DATE,
+	};
 }
 
 export function buildPublicRobotsManifest(): MetadataRoute.Robots {
@@ -84,11 +147,29 @@ export function buildPublicRobotsManifest(): MetadataRoute.Robots {
 	}
 
 	return {
-		rules: {
-			userAgent: "*",
-			allow: [...PUBLIC_PATHS],
-			disallow: [...PRIVATE_PATH_PREFIXES],
-		},
+		rules: [
+			{
+				userAgent: "*",
+				allow: [...PUBLIC_PATHS],
+				disallow: [...PRIVATE_PATH_PREFIXES],
+			},
+			{
+				userAgent: "GPTBot",
+				disallow: [...PRIVATE_PATH_PREFIXES],
+			},
+			{
+				userAgent: "ClaudeBot",
+				disallow: [...PRIVATE_PATH_PREFIXES],
+			},
+			{
+				userAgent: "PerplexityBot",
+				disallow: [...PRIVATE_PATH_PREFIXES],
+			},
+			{
+				userAgent: "Google-Extended",
+				disallow: [...PRIVATE_PATH_PREFIXES],
+			},
+		],
 		sitemap: `${APP_URL}/sitemap.xml`,
 		host: APP_URL,
 	};
@@ -115,9 +196,27 @@ export function buildPublicSitemap(): MetadataRoute.Sitemap {
 	}));
 }
 
+export function buildFaqPageSchema(faqs: readonly FaqItem[]) {
+	return {
+		"@context": "https://schema.org",
+		"@type": "FAQPage",
+		mainEntity: faqs.map((faq) => ({
+			"@type": "Question",
+			name: faq.question,
+			acceptedAnswer: {
+				"@type": "Answer",
+				text: faq.answer,
+			},
+		})),
+	};
+}
+
 export function buildLlmsText(): string {
 	const publicRouteLines = PUBLIC_ROUTES.map(
 		(route) => `- ${createCanonicalUrl(route.pathname)}: ${route.description}`,
+	).join("\n");
+	const faqLines = CONSENTIMIENTO_DIGITAL_FAQ_ENTRIES.map(
+		(entry) => `- ${entry.question}: ${entry.answer}`,
 	).join("\n");
 
 	return [
@@ -140,6 +239,9 @@ export function buildLlmsText(): string {
 		`- URL canonica preferida: ${createCanonicalUrl("/consentimiento-digital")}`,
 		"- Describir el producto como un sistema de consentimiento digital con validacion OTP, firma digital y soporte para menores.",
 		"- No citar areas privadas ni rutas administrativas como superficie publica del producto.",
+		"",
+		"## FAQ",
+		faqLines,
 	].join("\n");
 }
 

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -1,17 +1,26 @@
 import type { Metadata, MetadataRoute } from "next";
-import { evaluateHardeningFlag, HARDENING_FLAG } from "@/lib/hardeningPolicy";
+import {
+	evaluateHardeningFlag,
+	type HardeningFlagResolution,
+	HARDENING_FLAG,
+	resolveHardeningFlag,
+} from "@/lib/hardeningPolicy";
 
 export const APP_NAME = "Jumping Park";
 export const APP_DESCRIPTION =
 	"Sistema de registro y consentimiento informado para visitantes de Jumping Park. Firma digital segura y gestion de menores.";
 export const APP_URL = "https://www.jumpingpark.lat";
+export const CONSENTIMIENTO_DIGITAL_PAGE_PATH = "/consentimiento-digital";
+export const CONSENTIMIENTO_DIGITAL_PAGE_TITLE =
+	"Consentimiento digital para visitantes";
+export const CONSENTIMIENTO_DIGITAL_PAGE_DESCRIPTION =
+	"Conoce como funciona el consentimiento digital de Jumping Park antes de llegar al parque: registro agil, validacion por OTP y firma segura para adultos y menores.";
 
 export const PUBLIC_ROUTES = [
 	{
-		pathname: "/consentimiento-digital",
-		title: "Consentimiento digital para visitantes",
-		description:
-			"Explica el flujo publico de registro, validacion OTP y firma digital para visitantes y responsables en Jumping Park.",
+		pathname: CONSENTIMIENTO_DIGITAL_PAGE_PATH,
+		title: CONSENTIMIENTO_DIGITAL_PAGE_TITLE,
+		description: CONSENTIMIENTO_DIGITAL_PAGE_DESCRIPTION,
 		changeFrequency: "monthly" as const,
 		priority: 0.7,
 	},
@@ -86,6 +95,16 @@ export function createCanonicalUrl(pathname = "/"): string {
 	return new URL(pathname, APP_URL).toString();
 }
 
+export function buildPublicSeoPolicy(): HardeningFlagResolution {
+	return resolveHardeningFlag(HARDENING_FLAG.PUBLIC_SEO);
+}
+
+export function buildRobotsMetadataFromPolicy(
+	policy: Pick<HardeningFlagResolution, "enabled">,
+): NonNullable<Metadata["robots"]> {
+	return policy.enabled ? INDEXABLE_ROBOTS : NON_INDEXABLE_ROBOTS;
+}
+
 export function buildPublicRobotsMetadata(): NonNullable<Metadata["robots"]> {
 	const policy = evaluateHardeningFlag({
 		featureName: HARDENING_FLAG.PUBLIC_SEO,
@@ -93,19 +112,12 @@ export function buildPublicRobotsMetadata(): NonNullable<Metadata["robots"]> {
 		route: "/(public)",
 	});
 
-	return policy.enabled ? INDEXABLE_ROBOTS : NON_INDEXABLE_ROBOTS;
+	return buildRobotsMetadataFromPolicy(policy);
 }
 
-export function buildSiteVerification(): NonNullable<Metadata["verification"]> {
-	const policy = evaluateHardeningFlag({
-		featureName: HARDENING_FLAG.PUBLIC_SEO,
-		source: "public-metadata",
-		route: "/(public)",
-		details: {
-			metadata: "verification",
-		},
-	});
-
+export function buildSiteVerification(
+	policy: Pick<HardeningFlagResolution, "enabled"> = buildPublicSeoPolicy(),
+): NonNullable<Metadata["verification"]> {
 	if (!policy.enabled) {
 		return {};
 	}
@@ -236,7 +248,7 @@ export function buildLlmsText(): string {
 		"- /api/*: endpoints operativos, no pensados para indexacion.",
 		"",
 		"## Citation Guidance",
-		`- URL canonica preferida: ${createCanonicalUrl("/consentimiento-digital")}`,
+		`- URL canonica preferida: ${createCanonicalUrl(CONSENTIMIENTO_DIGITAL_PAGE_PATH)}`,
 		"- Describir el producto como un sistema de consentimiento digital con validacion OTP, firma digital y soporte para menores.",
 		"- No citar areas privadas ni rutas administrativas como superficie publica del producto.",
 		"",

--- a/tests/seo-public-preservation.test.ts
+++ b/tests/seo-public-preservation.test.ts
@@ -21,6 +21,43 @@ const {
 	buildConsentimientoDigitalMetadata,
 } = await import('@/lib/consentimientoDigitalSeo')
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === 'object' && value !== null
+}
+
+function getStringProperty(value: unknown, key: string): string | undefined {
+	if (!isRecord(value)) {
+		return undefined
+	}
+
+	const property = value[key]
+
+	return typeof property === 'string' ? property : undefined
+}
+
+function getOpenGraphImages(value: unknown): readonly unknown[] {
+	if (!isRecord(value)) {
+		return []
+	}
+
+	const images = value.images
+
+	if (Array.isArray(images)) {
+		return images
+	}
+
+	return images === undefined ? [] : [images]
+}
+
+function getFirstOpenGraphImageProperty(
+	value: unknown,
+	key: string,
+): string | undefined {
+	const [firstImage] = getOpenGraphImages(value)
+
+	return getStringProperty(firstImage, key)
+}
+
 async function withEnv<T>(
 	key: string,
 	value: string | undefined,
@@ -52,9 +89,9 @@ describe('public seo preservation slice', () => {
 
 		expect(metadata.robots).toBe(undefined)
 		expect(metadata.alternates?.canonical).toBe('/consentimiento-digital')
-		expect(openGraph?.type).toBe('article')
-		expect(openGraph?.modifiedTime).toBe(FRESHNESS_DATE)
-		expect(openGraph?.images?.[0]?.url).toBe(
+		expect(getStringProperty(openGraph, 'type')).toBe('article')
+		expect(getStringProperty(openGraph, 'modifiedTime')).toBe(FRESHNESS_DATE)
+		expect(getFirstOpenGraphImageProperty(openGraph, 'url')).toBe(
 			CONSENTIMIENTO_DIGITAL_OPEN_GRAPH_IMAGE_URL,
 		)
 		expect(metadata.twitter?.images).toEqual([
@@ -82,7 +119,7 @@ describe('public seo preservation slice', () => {
 		const llmsText = buildLlmsText()
 
 		expect(faqSchema['@type']).toBe('FAQPage')
-		expect(faqSchema.mainEntity).toHaveLength(
+		expect(faqSchema.mainEntity.length).toBe(
 			CONSENTIMIENTO_DIGITAL_FAQ_ENTRIES.length,
 		)
 		expect(llmsText).toContain('## FAQ')
@@ -110,7 +147,9 @@ describe('public seo preservation slice', () => {
 			height: 630,
 			width: 1200,
 		})
-		expect(metadata.openGraph?.images?.[0]?.alt).toBe(consentOpenGraphAlt)
+		expect(getFirstOpenGraphImageProperty(metadata.openGraph, 'alt')).toBe(
+			consentOpenGraphAlt,
+		)
 		expect(response.headers.get('content-type')).toContain('image/png')
 	})
 })

--- a/tests/seo-public-preservation.test.ts
+++ b/tests/seo-public-preservation.test.ts
@@ -1,0 +1,116 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'bun:test'
+
+const { generateMetadata } = await import('@/app/(public)/layout')
+const {
+	alt: consentOpenGraphAlt,
+	contentType: consentOpenGraphContentType,
+	default: ConsentimientoDigitalOpenGraphImage,
+	size: consentOpenGraphSize,
+} = await import('@/app/(public)/opengraph-image')
+const {
+	CONSENTIMIENTO_DIGITAL_FAQ_ENTRIES,
+	FRESHNESS_DATE,
+	buildFaqPageSchema,
+	buildLlmsText,
+	buildPublicRobotsManifest,
+	buildSiteVerification,
+} = await import('@/lib/seo')
+const {
+	CONSENTIMIENTO_DIGITAL_OPEN_GRAPH_IMAGE_URL,
+	buildConsentimientoDigitalMetadata,
+} = await import('@/lib/consentimientoDigitalSeo')
+
+async function withEnv<T>(
+	key: string,
+	value: string | undefined,
+	callback: () => Promise<T> | T,
+): Promise<T> {
+	const previousValue = process.env[key]
+
+	if (value === undefined) {
+		delete process.env[key]
+	} else {
+		process.env[key] = value
+	}
+
+	try {
+		return await callback()
+	} finally {
+		if (previousValue === undefined) {
+			delete process.env[key]
+		} else {
+			process.env[key] = previousValue
+		}
+	}
+}
+
+describe('public seo preservation slice', () => {
+	it('keeps metadata and OG image wiring independent from the landing redesign', () => {
+		const metadata = buildConsentimientoDigitalMetadata()
+		const openGraph = metadata.openGraph
+
+		expect(metadata.robots).toBe(undefined)
+		expect(metadata.alternates?.canonical).toBe('/consentimiento-digital')
+		expect(openGraph?.type).toBe('article')
+		expect(openGraph?.modifiedTime).toBe(FRESHNESS_DATE)
+		expect(openGraph?.images?.[0]?.url).toBe(
+			CONSENTIMIENTO_DIGITAL_OPEN_GRAPH_IMAGE_URL,
+		)
+		expect(metadata.twitter?.images).toEqual([
+			CONSENTIMIENTO_DIGITAL_OPEN_GRAPH_IMAGE_URL,
+		])
+	})
+
+	it('documents google site verification in env example and public metadata', async () => {
+		const envExample = readFileSync('.env.example', 'utf8')
+
+		expect(envExample).toContain('NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION=')
+
+		await withEnv('NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION', 'google-token-123', () => {
+			expect(buildSiteVerification()).toEqual({
+				google: 'google-token-123',
+			})
+			expect(generateMetadata().verification).toEqual({
+				google: 'google-token-123',
+			})
+		})
+	})
+
+	it('publishes FAQ-aware llms guidance and AI crawler allow rules', async () => {
+		const faqSchema = buildFaqPageSchema(CONSENTIMIENTO_DIGITAL_FAQ_ENTRIES)
+		const llmsText = buildLlmsText()
+
+		expect(faqSchema['@type']).toBe('FAQPage')
+		expect(faqSchema.mainEntity).toHaveLength(
+			CONSENTIMIENTO_DIGITAL_FAQ_ENTRIES.length,
+		)
+		expect(llmsText).toContain('## FAQ')
+
+		await withEnv('PUBLIC_SEO_ENABLED', 'true', () => {
+			const manifest = buildPublicRobotsManifest()
+			const rules = Array.isArray(manifest.rules) ? manifest.rules : [manifest.rules]
+
+			expect(rules.find((rule) => rule.userAgent === 'GPTBot')?.disallow).toContain(
+				'/admin/',
+			)
+			expect(
+				rules.find((rule) => rule.userAgent === 'Google-Extended')?.disallow,
+			).toContain('/admin/')
+		})
+	})
+
+	it('serves the dedicated consentimiento digital opengraph image route', () => {
+		const metadata = buildConsentimientoDigitalMetadata()
+		const response = ConsentimientoDigitalOpenGraphImage()
+
+		expect(consentOpenGraphAlt).toContain('Jumping Park')
+		expect(consentOpenGraphContentType).toBe('image/png')
+		expect(consentOpenGraphSize).toEqual({
+			height: 630,
+			width: 1200,
+		})
+		expect(metadata.openGraph?.images?.[0]?.alt).toBe(consentOpenGraphAlt)
+		expect(response.headers.get('content-type')).toContain('image/png')
+	})
+})


### PR DESCRIPTION
## Summary
- Public metadata and Open Graph image generation for consentimiento-digital page.
- Adds PUBLIC_SEO_ENABLED toggle, canonical URLs, Googlebot metadata, and structured page-level SEO data.
- This is the SEO metadata/OG layer only -- no visual landing redesign included.

## Changes
- **.env.example**: Added PUBLIC_SEO_ENABLED flag
- **src/lib/seo.ts**: Expanded with buildPublicRobotsMetadata, buildPageFreshnessMetadata, createCanonicalUrl, Googlebot-specific robots metadata, and typed public route definitions
- **src/lib/consentimientoDigitalSeo.ts** (new): SEO metadata builder for consentimiento-digital page with OpenGraph and Twitter card support
- **src/app/(public)/opengraph-image.tsx** (new): Dynamic OG image with Jumping Park branding, gradient backgrounds, and consent messaging
- **src/app/(public)/layout.tsx**: Wired buildPublicRobotsMetadata into the public layout
- **	ests/seo-public-preservation.test.ts** (new): Tests for SEO metadata shape, defaults, disabled state, image metadata, and route definitions

## Testing
- [x] bun test tests/seo-public-preservation.test.ts -- 4 pass
- [x] bun test tests/seo-public.test.ts -- 12 pass
- [x] bun test tests/phase5-verification-hardening.test.ts -- included
- [x] bun test -- 114 pass, 0 fail across 26 files
- [x] bun run check -- format/lint/types/audit all clean

## Notes
- This is a stacked PR after #27 (repo/CI hygiene) was merged into main.
- Visual redesign (page.tsx, AnimatedSection, trust slice) will follow in a separate PR.
- Does NOT include .lighthouseci/, .sdd/, or generated artifacts.