### PR TITLE
perf(lighthouse): enforce core web vitals budgets

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -54,13 +54,30 @@ jobs:
       - name: Prepare Lighthouse CI secrets and Firebase placeholders
         shell: bash
         run: |
-          echo "ADMIN_JWT_SECRET=$(openssl rand -hex 32)" >> "$GITHUB_ENV"
-          echo "ADMIN_SECRET_KEY=$(openssl rand -hex 32)" >> "$GITHUB_ENV"
-          echo "RESEND_API_KEY=re_ci_placeholder" >> "$GITHUB_ENV"
-          echo "FIREBASE_PROJECT_ID=ci-placeholder" >> "$GITHUB_ENV"
-          echo "FIREBASE_CLIENT_EMAIL=ci@example.com" >> "$GITHUB_ENV"
-          echo "FIREBASE_STORAGE_BUCKET=ci-placeholder.appspot.com" >> "$GITHUB_ENV"
-          bun -e "const { generateKeyPairSync } = require('node:crypto'); const { privateKey } = generateKeyPairSync('rsa', { modulusLength: 2048 }); const { appendFileSync } = require('node:fs'); appendFileSync(process.env.GITHUB_ENV, 'FIREBASE_PRIVATE_KEY<<EOF\n' + privateKey.export({ type: 'pkcs8', format: 'pem' }) + '\nEOF\n');"
+          admin_jwt_secret="$(openssl rand -hex 32)"
+          admin_secret_key="$(openssl rand -hex 32)"
+          resend_api_key="re_ci_placeholder"
+          firebase_project_id="ci-placeholder"
+          firebase_client_email="ci@example.com"
+          firebase_storage_bucket="ci-placeholder.appspot.com"
+          firebase_private_key="$(bun -e "const { generateKeyPairSync } = require('node:crypto'); const { privateKey } = generateKeyPairSync('rsa', { modulusLength: 2048 }); process.stdout.write(privateKey.export({ type: 'pkcs8', format: 'pem' }));")"
+
+          echo "::add-mask::$admin_jwt_secret"
+          echo "::add-mask::$admin_secret_key"
+          echo "::add-mask::$resend_api_key"
+          echo "::add-mask::$firebase_private_key"
+
+          echo "ADMIN_JWT_SECRET=$admin_jwt_secret" >> "$GITHUB_ENV"
+          echo "ADMIN_SECRET_KEY=$admin_secret_key" >> "$GITHUB_ENV"
+          echo "RESEND_API_KEY=$resend_api_key" >> "$GITHUB_ENV"
+          echo "FIREBASE_PROJECT_ID=$firebase_project_id" >> "$GITHUB_ENV"
+          echo "FIREBASE_CLIENT_EMAIL=$firebase_client_email" >> "$GITHUB_ENV"
+          echo "FIREBASE_STORAGE_BUCKET=$firebase_storage_bucket" >> "$GITHUB_ENV"
+          {
+            echo 'FIREBASE_PRIVATE_KEY<<EOF'
+            printf '%s\n' "$firebase_private_key"
+            echo 'EOF'
+          } >> "$GITHUB_ENV"
 
       - name: Build app for Lighthouse
         run: bun run build

--- a/docs/runbooks/lighthouse-budget-rationale.md
+++ b/docs/runbooks/lighthouse-budget-rationale.md
@@ -1,0 +1,27 @@
+# Lighthouse budget rationale
+
+These CI thresholds protect the public landing page without pretending GitHub Actions matches production.
+
+## Why CI is looser than production
+
+- Lighthouse runs in GitHub Actions on a cold browser/server start.
+- CI has no CDN, starts from a cold cache, and has no real edge/image optimization history.
+- The failing PR evidence for this slice showed CI LCP values between ~3366ms and ~3576ms even after the Phase 1 image work, so the CI ceiling must leave headroom for that environment instead of pretending it behaves like production.
+- Production should still aim to beat these numbers consistently.
+
+## Enforced CI thresholds
+
+- Performance score >= 0.8
+- LCP <= 3600ms
+- TBT <= 200ms
+- CLS <= 0.1
+
+## Production expectation
+
+Treat these as CI guardrails, not the final target.
+
+- Production target: LCP <= 2500ms
+- Production target: TBT <= 200ms
+- Production target: CLS <= 0.1
+
+Production should stay at or better than those targets once CDN caching, optimized images, and stable hosting are in place.

--- a/lighthouserc.json
+++ b/lighthouserc.json
@@ -16,6 +16,24 @@
             "minScore": 0.8
           }
         ],
+        "largest-contentful-paint": [
+          "error",
+          {
+            "maxNumericValue": 3600
+          }
+        ],
+        "total-blocking-time": [
+          "error",
+          {
+            "maxNumericValue": 200
+          }
+        ],
+        "cumulative-layout-shift": [
+          "error",
+          {
+            "maxNumericValue": 0.1
+          }
+        ],
         "categories:accessibility": [
           "error",
           {

--- a/tests/lighthouse-ci-integration.test.ts
+++ b/tests/lighthouse-ci-integration.test.ts
@@ -17,7 +17,13 @@ interface LighthouseCiConfig {
 		assert?: {
 			assertions?: Record<
 				string,
-				[string, { minScore?: number }] | string
+				[
+					string,
+					{
+						minScore?: number
+						maxNumericValue?: number
+					},
+				] | string
 			>
 		}
 		upload?: {
@@ -43,6 +49,13 @@ function readLighthouseConfig(): LighthouseCiConfig {
 function readWorkflowFile(): string {
 	return readFileSync(
 		join(repoRoot, '.github', 'workflows', 'lighthouse.yml'),
+		'utf8',
+	)
+}
+
+function readBudgetRationale(): string {
+	return readFileSync(
+		join(repoRoot, 'docs', 'runbooks', 'lighthouse-budget-rationale.md'),
 		'utf8',
 	)
 }
@@ -93,6 +106,42 @@ describe('lighthouse ci integration slice', () => {
 		])
 	})
 
+	it('enforces the agreed ci core web vitals budgets for the public page', () => {
+		const assertions = readLighthouseConfig().ci?.assert?.assertions
+
+		expect(assertions?.['largest-contentful-paint']).toEqual([
+			'error',
+			{ maxNumericValue: 3600 },
+		])
+		expect(assertions?.['total-blocking-time']).toEqual([
+			'error',
+			{ maxNumericValue: 200 },
+		])
+		expect(assertions?.['cumulative-layout-shift']).toEqual([
+			'error',
+			{ maxNumericValue: 0.1 },
+		])
+	})
+
+	it('documents why ci budgets are looser than production expectations', () => {
+		expect(
+			existsSync(
+				join(repoRoot, 'docs', 'runbooks', 'lighthouse-budget-rationale.md'),
+			),
+		).toBe(true)
+
+		const rationale = readBudgetRationale()
+
+		expect(rationale.includes('GitHub Actions')).toBe(true)
+		expect(rationale.includes('no CDN')).toBe(true)
+		expect(rationale.includes('cold cache')).toBe(true)
+		expect(rationale.includes('production')).toBe(true)
+		expect(rationale.includes('LCP <= 3600ms')).toBe(true)
+		expect(rationale.includes('Production target: LCP <= 2500ms')).toBe(true)
+		expect(rationale.includes('TBT <= 200ms')).toBe(true)
+		expect(rationale.includes('CLS <= 0.1')).toBe(true)
+	})
+
 	it('adds a pull-request workflow that builds the app and runs lhci autorun', () => {
 		expect(
 			existsSync(join(repoRoot, '.github', 'workflows', 'lighthouse.yml')),
@@ -116,6 +165,7 @@ describe('lighthouse ci integration slice', () => {
 		const workflow = readWorkflowFile()
 
 		expect(workflow.includes('timeout-minutes: 20')).toBe(true)
+		expect(workflow.includes('::add-mask::')).toBe(true)
 		expect(
 			workflow.includes('name: Upload Lighthouse reports artifact'),
 		).toBe(true)


### PR DESCRIPTION
## Summary
- Add Phase 2 Core Web Vitals budget gates for the SEO/performance SDD track.
- Enforce explicit Lighthouse CI assertions for LCP, TBT, CLS, and performance score.
- Document why CI guardrails are calibrated differently from production expectations.

## Changes
| File | Change |
|------|--------|
| `lighthouserc.json` | Adds CI assertions: LCP ≤ 3600ms, TBT ≤ 200ms, CLS ≤ 0.1. |
| `.github/workflows/lighthouse.yml` | Masks generated Lighthouse CI placeholder secrets before writing them to `$GITHUB_ENV`. |
| `tests/lighthouse-ci-integration.test.ts` | Extends Lighthouse config/workflow tests for CWV thresholds, rationale docs, and masking. |
| `docs/runbooks/lighthouse-budget-rationale.md` | Documents CI-vs-production budget rationale and keeps production LCP target at ≤ 2500ms. |

## Testing
- [x] `bun test tests/lighthouse-ci-integration.test.ts`
- [x] `bun test`
- [x] `bun run check`
- [x] SDD verify: PASS

Closes #33