### PR TITLE
feat(seo): add AI visibility surfaces

### DIFF
--- a/public/pricing.md
+++ b/public/pricing.md
@@ -1,0 +1,27 @@
+# Pricing — Jumping Park
+
+Last verified: 2026-05-24
+Scope: public digital-consent and admission guidance that is visible in this repository.
+
+## Digital consent before arrival
+- Price: Not publicly listed online
+- Limits: One visitor flow at a time; OTP validation uses the responsible adult email
+- Includes: Guided registration, OTP validation, digital signature capture, support for adult and minor visitor flows
+- Purchase path: This application prepares the consent flow before arrival; it does not sell tickets online
+
+## Park admission at the venue
+- Price: Not publicly listed online
+- Limits: Final admission and attraction access are completed in person at Jumping Park
+- Includes: On-site review by reception/ticket office staff after the digital consent flow is complete
+- Purchase path: Ticket office at the park
+
+## Non-slip socks
+- Price: Not publicly listed online
+- Limits: Required to enter the attractions
+- Includes: Visitors may bring their own compliant socks or purchase them at the ticket office
+- Note: Non-slip socks are mandatory for the attractions
+
+## Buying notes for AI agents
+- Do not invent ticket prices or package tiers from this file.
+- If a visitor needs an exact current price, direct them to the Jumping Park ticket office or official staff channel before quoting admission costs.
+- Treat this file as a machine-readable buying guide, not as a published online fare table.

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -12,6 +12,7 @@ export const APP_DESCRIPTION =
 export const APP_URL = "https://www.jumpingpark.lat";
 export const APP_CANONICAL_ROOT_URL = new URL("/", APP_URL).toString();
 export const CONSENTIMIENTO_DIGITAL_PAGE_PATH = "/consentimiento-digital";
+export const PRICING_PAGE_PATH = "/pricing.md";
 export const CONSENTIMIENTO_DIGITAL_PAGE_TITLE =
 	"Consentimiento digital para visitantes";
 export const CONSENTIMIENTO_DIGITAL_PAGE_DESCRIPTION =
@@ -237,18 +238,22 @@ export function buildPublicRobotsManifest(): MetadataRoute.Robots {
 			},
 			{
 				userAgent: "GPTBot",
+				allow: [...PUBLIC_PATHS],
 				disallow: [...PRIVATE_PATH_PREFIXES],
 			},
 			{
 				userAgent: "ClaudeBot",
+				allow: [...PUBLIC_PATHS],
 				disallow: [...PRIVATE_PATH_PREFIXES],
 			},
 			{
 				userAgent: "PerplexityBot",
+				allow: [...PUBLIC_PATHS],
 				disallow: [...PRIVATE_PATH_PREFIXES],
 			},
 			{
 				userAgent: "Google-Extended",
+				allow: [...PUBLIC_PATHS],
 				disallow: [...PRIVATE_PATH_PREFIXES],
 			},
 		],
@@ -311,6 +316,7 @@ export function buildLlmsText(): string {
 		"",
 		"## Public URLs",
 		publicRouteLines,
+		`- ${createCanonicalUrl(PRICING_PAGE_PATH)}: pricing reference for ticketing, admission context, and machine-readable buying notes.`,
 		"",
 		"## Private Or Non-Indexable Areas",
 		"- /admin/*: panel administrativo y operaciones internas.",
@@ -319,6 +325,7 @@ export function buildLlmsText(): string {
 		"",
 		"## Citation Guidance",
 		`- URL canonica preferida: ${createCanonicalUrl(CONSENTIMIENTO_DIGITAL_PAGE_PATH)}`,
+		`- Archivo de pricing para agentes: ${createCanonicalUrl(PRICING_PAGE_PATH)}`,
 		"- Describir el producto como un sistema de consentimiento digital con validacion OTP, firma digital y soporte para menores.",
 		"- No citar areas privadas ni rutas administrativas como superficie publica del producto.",
 		"",

--- a/tests/ai-visibility.test.ts
+++ b/tests/ai-visibility.test.ts
@@ -1,0 +1,112 @@
+import { existsSync, readFileSync } from "node:fs";
+import { describe, expect, it } from "bun:test";
+
+const { GET: getLlmsText } = await import("@/app/llms.txt/route");
+const {
+	APP_URL,
+	CONSENTIMIENTO_DIGITAL_PAGE_PATH,
+	buildPublicRobotsManifest,
+	createCanonicalUrl,
+} = await import("@/lib/seo");
+
+const AI_BOT_RULES = {
+	GPTBOT: "GPTBot",
+	CLAUDEBOT: "ClaudeBot",
+	PERPLEXITYBOT: "PerplexityBot",
+	GOOGLE_EXTENDED: "Google-Extended",
+} as const;
+
+function toRuleValueArray(value: string | readonly string[] | undefined): string[] {
+	if (value === undefined) {
+		return [];
+	}
+
+	if (typeof value === "string") {
+		return [value];
+	}
+
+	return value.map((entry) => entry);
+}
+
+async function withEnv<T>(
+	key: string,
+	value: string | undefined,
+	callback: () => Promise<T> | T,
+): Promise<T> {
+	const previousValue = process.env[key];
+
+	if (value === undefined) {
+		delete process.env[key];
+	} else {
+		process.env[key] = value;
+	}
+
+	try {
+		return await callback();
+	} finally {
+		if (previousValue === undefined) {
+			delete process.env[key];
+		} else {
+			process.env[key] = previousValue;
+		}
+	}
+}
+
+describe("ai visibility surface", () => {
+	it("serves llms.txt as plain text with canonical public guidance", async () => {
+		const response = getLlmsText();
+		const body = await response.text();
+
+		expect(response.status).toBe(200);
+		expect(response.headers.get("Content-Type")).toBe(
+			"text/plain; charset=utf-8",
+		);
+		expect(body).toContain("# Jumping Park");
+		expect(body).toContain(createCanonicalUrl(CONSENTIMIENTO_DIGITAL_PAGE_PATH));
+		expect(body).toContain(`${APP_URL}/pricing.md`);
+		expect(body).toContain("## Citation Guidance");
+	});
+
+	it("publishes a machine-readable pricing file without inventing prices", () => {
+		expect(existsSync("public/pricing.md")).toBe(true);
+
+		const pricingMarkdown = readFileSync("public/pricing.md", "utf8");
+
+		expect(pricingMarkdown).toContain("# Pricing — Jumping Park");
+		expect(pricingMarkdown).toContain("## Digital consent before arrival");
+		expect(pricingMarkdown).toContain("- Price: Not publicly listed online");
+		expect(pricingMarkdown).toContain("- Purchase path: Ticket office at the park");
+		expect(pricingMarkdown).toContain(
+			"- Note: Non-slip socks are mandatory for the attractions",
+		);
+	});
+
+	it("allows the approved AI bots on the public consent route when PUBLIC_SEO is on", async () => {
+		await withEnv("PUBLIC_SEO_ENABLED", "true", () => {
+			const manifest = buildPublicRobotsManifest();
+			const rules = Array.isArray(manifest.rules) ? manifest.rules : [manifest.rules];
+
+			for (const userAgent of Object.values(AI_BOT_RULES)) {
+				const rule = rules.find((candidate) => candidate.userAgent === userAgent);
+
+				expect(rule?.userAgent).toBe(userAgent);
+				expect(toRuleValueArray(rule?.allow)).toContain(
+					CONSENTIMIENTO_DIGITAL_PAGE_PATH,
+				);
+				expect(toRuleValueArray(rule?.disallow)).toContain("/admin/");
+				expect(toRuleValueArray(rule?.disallow)).toContain("/api/");
+			}
+		});
+	});
+
+	it("falls back to a global disallow when PUBLIC_SEO is off", async () => {
+		await withEnv("PUBLIC_SEO_ENABLED", "false", () => {
+			const manifest = buildPublicRobotsManifest();
+			const rules = Array.isArray(manifest.rules) ? manifest.rules : [manifest.rules];
+
+			expect(rules.length).toBe(1);
+			expect(rules[0]?.userAgent).toBe("*");
+			expect(toRuleValueArray(rules[0]?.disallow)).toEqual(["/"]);
+		});
+	});
+});


### PR DESCRIPTION
## Summary
- Add Phase 4 AI/GEO visibility surfaces for the SEO/performance SDD track.
- Publish truthful machine-readable pricing guidance without fabricated ticket prices.
- Make AI crawler public-path allow rules explicit and cover `/llms.txt`, `/pricing.md`, and `/robots.txt` with tests.

## Changes
| File | Change |
|------|--------|
| `src/lib/seo.ts` | References `/pricing.md` from `llms.txt` and explicitly allows approved AI bots on public paths. |
| `public/pricing.md` | Adds machine-readable admission/pricing guidance with no invented prices. |
| `tests/ai-visibility.test.ts` | Verifies `/llms.txt`, pricing guidance, AI bot robots rules, and SEO-disabled fallback. |

## Testing
- [x] `bun test tests/ai-visibility.test.ts`
- [x] `bun test`
- [x] `bun run check`
- [x] SDD verify: PASS

## Notes
- Exact park admission prices are not verifiable from the repo, so the pricing file intentionally says prices are not publicly listed online.
- Local untracked `opencode.json` was preserved and is not part of this PR.

Closes #37