### PR TITLE
docs(seo): add AI visibility monitoring checklist

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -1,4 +1,4 @@
-name: Lighthouse CI
+name: Lighthouse public audit (SEO min 0.9)
 
 on:
   pull_request:
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   lighthouse:
-    name: Lighthouse CI audit
+    name: Lighthouse public audit (SEO min 0.9)
     runs-on: ubuntu-latest
     timeout-minutes: 20
     env:

--- a/docs/ai-visibility-monthly-checklist.md
+++ b/docs/ai-visibility-monthly-checklist.md
@@ -1,0 +1,55 @@
+# AI visibility monthly checklist
+
+Run this once per month for the public marketing surface.
+
+## Scope
+
+- Check Google AI Overviews, ChatGPT, and Perplexity.
+- Use at least 5 target queries tied to public discovery intent.
+- Review the live public assets that agents cite today: `/llms.txt`, `/pricing.md`, `robots.txt`, `sitemap.xml`, and `/consentimiento-digital`.
+
+## Preconditions
+
+- `PUBLIC_SEO_ENABLED=true`
+- fresh deploy on the environment being checked
+- canonical public URL available
+
+## Monthly steps
+
+1. Pick at least 5 target queries. Recommended mix:
+   - `jumping park consentimiento digital`
+   - `parque de trampolines rosario consentimiento`
+   - `jumping park precios`
+   - `jumping park cumpleaños rosario`
+   - `jumping park menores consentimiento`
+2. Run each query in Google AI Overviews, ChatGPT, and Perplexity.
+3. For every answer, capture:
+   - whether Jumping Park is cited;
+   - which URL is cited;
+   - whether the answer stays truthful to `/llms.txt` and `/pricing.md`;
+   - which competitor or third-party source appears instead.
+4. Confirm `robots.txt` still allows the approved AI bots on public routes and still blocks private surfaces.
+5. Confirm `sitemap.xml` and the canonical public URL still match the current deploy.
+6. If the brand is missing or misrepresented, open a follow-up issue with the failed query, platform, cited source, and the public page that should be improved.
+
+## Results log
+
+| Month | Query | Platform | Jumping Park cited? | Cited URL | Competitor/source cited | Notes / follow-up |
+| --- | --- | --- | --- | --- | --- | --- |
+| YYYY-MM |  | Google AI Overviews | Yes / No |  |  |  |
+| YYYY-MM |  | ChatGPT | Yes / No |  |  |  |
+| YYYY-MM |  | Perplexity | Yes / No |  |  |  |
+
+## Rollback by phase
+
+| Phase | What changed | First rollback move | Verify after rollback |
+| --- | --- | --- | --- |
+| Phase 1 — image optimization | optimized public assets, shared image config, responsive `sizes` | revert the image-optimization slice if visual regressions or broken asset paths appear | `bun test tests/images.test.tsx` |
+| Phase 2 — Lighthouse budgets | `lighthouserc.json`, Lighthouse workflow, CI-vs-production rationale | revert the Lighthouse budget slice if the thresholds or CI prep become untruthful | `bun test tests/lighthouse-ci-integration.test.ts` |
+| Phase 3 — structured data | `LocalBusiness`/`BreadcrumbList` output in public JSON-LD | revert the structured-data slice if validation fails or the schema becomes misleading | `bun test tests/structured-data.test.ts tests/phase5-verification-hardening.test.ts` |
+| Phase 4 — AI visibility surfaces | `/llms.txt` guidance, `/pricing.md`, AI bot allow rules | for emergency noindex use `PUBLIC_SEO_ENABLED=false`; for permanent rollback revert the AI-visibility slice | `bun test tests/ai-visibility.test.ts` plus `GET /robots.txt` |
+| Phase 5 — monitoring and CI naming | descriptive Lighthouse check name and this runbook | revert the docs/workflow slice if naming or operating guidance is wrong | `bun test tests/monitoring-ci-quality.test.ts tests/lighthouse-ci-integration.test.ts` |
+
+## Escalation rule
+
+If two consecutive monthly runs show that Jumping Park is absent for the same priority query on two or more platforms, treat it as a backlog item for public-content improvement instead of silently accepting the drift.

--- a/tests/lighthouse-ci-integration.test.ts
+++ b/tests/lighthouse-ci-integration.test.ts
@@ -33,6 +33,11 @@ interface LighthouseCiConfig {
 }
 
 const repoRoot = process.cwd()
+const lighthousePublicAuditName = 'Lighthouse public audit (SEO min 0.9)'
+
+function countOccurrences(value: string, needle: string): number {
+	return value.split(needle).length - 1
+}
 
 function readPackageJson(): PackageJsonShape {
 	return JSON.parse(
@@ -143,14 +148,16 @@ describe('lighthouse ci integration slice', () => {
 		expect(rationale.includes('CLS <= 0.1')).toBe(true)
 	})
 
-	it('adds a pull-request workflow that builds the app and runs lhci autorun', () => {
+	it('adds a pull-request workflow with a descriptive lighthouse check name', () => {
 		expect(
 			existsSync(join(repoRoot, '.github', 'workflows', 'lighthouse.yml')),
 		).toBe(true)
 
 		const workflow = readWorkflowFile()
 
-		expect(workflow.includes('name: Lighthouse CI')).toBe(true)
+		expect(workflow.includes(`name: ${lighthousePublicAuditName}`)).toBe(true)
+		expect(workflow.includes(`    name: ${lighthousePublicAuditName}`)).toBe(true)
+		expect(countOccurrences(workflow, lighthousePublicAuditName)).toBe(2)
 		expect(workflow.includes('pull_request:')).toBe(true)
 		expect(workflow.includes('uses: oven-sh/setup-bun@v2')).toBe(true)
 		expect(workflow.includes('run: bun install --frozen-lockfile')).toBe(true)

--- a/tests/monitoring-ci-quality.test.ts
+++ b/tests/monitoring-ci-quality.test.ts
@@ -1,0 +1,70 @@
+import { existsSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'bun:test'
+
+const repoRoot = process.cwd()
+const lighthousePublicAuditName = 'Lighthouse public audit (SEO min 0.9)'
+
+function readWorkflowFile(): string {
+	return readFileSync(
+		join(repoRoot, '.github', 'workflows', 'lighthouse.yml'),
+		'utf8',
+	)
+}
+
+function readMonthlyChecklist(): string {
+	return readFileSync(
+		join(repoRoot, 'docs', 'ai-visibility-monthly-checklist.md'),
+		'utf8',
+	)
+}
+
+function countOccurrences(value: string, needle: string): number {
+	return value.split(needle).length - 1
+}
+
+describe('phase 5 monitoring and ci quality slice', () => {
+	it('uses a descriptive lighthouse workflow name while preserving the lhci command', () => {
+		expect(
+			existsSync(join(repoRoot, '.github', 'workflows', 'lighthouse.yml')),
+		).toBe(true)
+
+		const workflow = readWorkflowFile()
+
+		expect(workflow.includes(`name: ${lighthousePublicAuditName}`)).toBe(true)
+		expect(workflow.includes(`    name: ${lighthousePublicAuditName}`)).toBe(true)
+		expect(countOccurrences(workflow, lighthousePublicAuditName)).toBe(2)
+		expect(
+			workflow.includes('run: bun x lhci autorun --config=./lighthouserc.json'),
+		).toBe(true)
+	})
+
+	it('adds a monthly ai visibility checklist for the required platforms and queries', () => {
+		expect(
+			existsSync(
+				join(repoRoot, 'docs', 'ai-visibility-monthly-checklist.md'),
+			),
+		).toBe(true)
+
+		const checklist = readMonthlyChecklist()
+
+		expect(checklist.includes('Google AI Overviews')).toBe(true)
+		expect(checklist.includes('ChatGPT')).toBe(true)
+		expect(checklist.includes('Perplexity')).toBe(true)
+		expect(checklist.includes('at least 5 target queries')).toBe(true)
+		expect(checklist.includes('Results log')).toBe(true)
+		expect(checklist.includes('/llms.txt')).toBe(true)
+		expect(checklist.includes('/pricing.md')).toBe(true)
+	})
+
+	it('documents rollback guidance for each seo audit phase', () => {
+		const checklist = readMonthlyChecklist()
+
+		expect(checklist.includes('Phase 1 — image optimization')).toBe(true)
+		expect(checklist.includes('Phase 2 — Lighthouse budgets')).toBe(true)
+		expect(checklist.includes('Phase 3 — structured data')).toBe(true)
+		expect(checklist.includes('Phase 4 — AI visibility surfaces')).toBe(true)
+		expect(checklist.includes('Phase 5 — monitoring and CI naming')).toBe(true)
+		expect(checklist.includes('PUBLIC_SEO_ENABLED=false')).toBe(true)
+	})
+})


### PR DESCRIPTION
## Summary
- Add Phase 5 monitoring and CI-quality guidance for the SEO/performance SDD track.
- Rename the Lighthouse workflow/check to a descriptive public audit name.
- Add a monthly AI visibility checklist with rollback guidance for each completed phase.

## Changes
| File | Change |
|------|--------|
| `.github/workflows/lighthouse.yml` | Renames the workflow/job to `Lighthouse public audit (SEO min 0.9)`. |
| `docs/ai-visibility-monthly-checklist.md` | Adds monthly AI visibility checks, result log template, and rollback matrix. |
| `tests/lighthouse-ci-integration.test.ts` | Updates the workflow naming contract. |
| `tests/monitoring-ci-quality.test.ts` | Verifies the Phase 5 monitoring/checklist/rollback contract. |

## Testing
- [x] `bun test tests/lighthouse-ci-integration.test.ts tests/monitoring-ci-quality.test.ts`
- [x] `bun test`
- [x] `bun run check`
- [x] SDD verify: PASS

## Notes
- Local untracked `opencode.json` was preserved and is not part of this PR.

Closes #39