### PR TITLE
docs(portfolio): establish documentation ia hub

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,51 +1,54 @@
-# Documentacion actual del repo
+# Documentation hub
 
-Este indice refleja el estado integrado del clean clone **despues de los Batches 1-4** del workflow `git-corrupted-reapply-workflow`.
+This is the entry point for the current documentation information architecture (IA). It uses Diátaxis as the navigation model and keeps every hub entry marked as `current`, `reference`, or `historical`.
 
-La regla editorial sigue igual de estricta: cada documento se marca segun su uso real hoy. Si un archivo conserva contexto viejo, roadmap o material historico, se dice explicitamente en vez de venderlo como verdad operativa.
+## Quick path
 
-## Current / usable hoy
+1. Start at `README.md` for the repo overview and quality gates.
+2. Read `docs/ARQUITECTURA.md` for the current system narrative.
+3. Use `docs/runbooks/production-hardening.md` as the operational hub.
+4. Open `docs/portfolio/README.md` when you need the portfolio/storytelling workspace.
+5. Use historical docs only when you need traceability for older project states.
 
-| Documento | Estado | Uso real hoy |
+## Tutorials
+
+No current tutorial is published yet. This hub keeps the IA ready for future tutorials without inventing content that does not exist in the repo today.
+
+| Path | Status | Role |
 | --- | --- | --- |
-| `docs/README.md` | Current | Mapa de verdad para separar documentacion actual vs historica |
-| `CONTRIBUTING.md` | Current | Flujo de contribucion, calidad y SDD del repo |
-| `CLAUDE.md` | Current | Convenciones operativas, comandos Bun y arquitectura vigente |
-| `diagramas/README.md` | Current | Guia de diagramas editables presentes en el repo |
-| `diagramas/Diagrama-Secuencia.mmd` | Current | Mermaid editable del flujo de alto nivel |
-| `diagramas/Diagrama-de-Entidad-Relacion.mmd` | Current | Mermaid editable del mapa de datos actual/referencial |
-| `docs/ARQUITECTURA.md` | Current | Narrativa tecnica vigente para kiosk, admin, SEO y rollout flags |
-| `docs/runbooks/production-hardening.md` | Current | Hub operativo para smoke checks, flags y release hardening |
-| `docs/runbooks/dependency-risk-note.md` | Current | Estado actual del riesgo de dependencias y politica de seguimiento |
-| `docs/runbooks/rollback-flags.md` | Current | Matriz de rollback de flags y condiciones de reversa |
-| `docs/runbooks/offline-replay-drill.md` | Current | Drill del replay offline para el rollout controlado |
-| `docs/runbooks/admin-cost-smoke-checklist.md` | Current | Checklist de costo admin para cursor/aggregates |
-| `docs/runbooks/seo-ai-seo-validation-checklist.md` | Current | Checklist de SEO, AI-SEO y smoke de accesibilidad |
-| `docs/portfolio/README.md` | Current | Plan curado de captura y storytelling, vigente aunque no todos los assets existan todavia |
+| `docs/MANUAL_USUARIO.md` | historical | Legacy end-user walkthrough kept only for traceability. |
 
-## Reference / leer con contexto
+## How-to guides
 
-| Documento | Estado | Nota |
+| Path | Status | Role |
 | --- | --- | --- |
-| `docs/portfolio/diagrams/README.md` | Reference | Guia de curacion para diagramas de portfolio; apoya al material actual pero no reemplaza `docs/ARQUITECTURA.md` |
-| `docs/portfolio/screenshots/README.md` | Reference | Checklist de capturas reales para portfolio/demo |
-| `docs/portfolio/motion/demo-script.md` | Reference | Guion de motion/GIF para storytelling, no contrato runtime |
-| `docs/portfolio/branding/logo-usage.md` | Reference | Recomendaciones visuales para presentacion externa |
-| `docs/portfolio/artifact-manifest.template.md` | Reference | Plantilla de inventario para assets reales |
+| `docs/runbooks/production-hardening.md` | current | Main operator path for release validation, rollout, and rollback checks. |
+| `docs/runbooks/rollback-flags.md` | current | Flag-by-flag rollback procedure for staged releases. |
+| `docs/runbooks/offline-replay-drill.md` | current | Step-by-step offline replay validation drill. |
+| `docs/runbooks/admin-cost-smoke-checklist.md` | current | Procedure for admin cost and aggregates smoke checks. |
+| `docs/runbooks/seo-ai-seo-validation-checklist.md` | current | Release checklist for SEO, AI visibility, and a11y smoke notes. |
+| `docs/ai-visibility-monthly-checklist.md` | current | Recurring monthly workflow for AI citation and discovery checks. |
+| `docs/runbooks/git-history-mp4-purge.md` | reference | Targeted history-rewrite procedure used only when coordinating a purge window. |
 
-## Historical / referencia solamente
+## Reference
 
-| Documento | Estado | Nota |
+| Path | Status | Role |
 | --- | --- | --- |
-| `docs/MANUAL_USUARIO.md` | Historical | Snapshot funcional previo |
-| `docs/MANUAL_INSTALACION.md` | Historical | Manual de despliegue anterior |
-| `docs/INFORME_TECNICO_SPRINT_3.md` | Historical | Informe puntual, no guia vigente |
-| `docs/ESTRUCTURA_PROYECTO.md` | Historical | Mapa legacy; validar contra el repo real |
+| `docs/ARQUITECTURA.md` | current | Current architecture narrative, rollout model, and cross-surface system map. |
+| `docs/runbooks/otp-operational-policy.md` | current | OTP runtime values, lockouts, and source-linked operational contract. |
+| `docs/runbooks/dependency-risk-note.md` | current | Current dependency risk position and accepted residual tooling debt. |
+| `docs/MANUAL_INSTALACION.md` | historical | Legacy installation guide that must be re-validated before reuse. |
+| `docs/ESTRUCTURA_PROYECTO.md` | historical | Legacy structure map kept only as historical context. |
 
-## Regla editorial
+## Explanation
 
-- Si cambia el estado real del repo, actualiza primero `README.md` y este indice.
-- `Current` significa usable hoy como verdad operativa o guia activa, aunque el documento describa un plan honesto (por ejemplo portfolio capture).
-- `Reference` significa apoyo util o curado, pero no la fuente primaria de verdad tecnica/operativa.
-- `Historical` significa contexto viejo que no debe competir con la documentacion vigente.
-- Si un archivo apunta a roadmap archivado, runbooks o assets, la referencia tiene que existir realmente en el repo.
+| Path | Status | Role |
+| --- | --- | --- |
+| `docs/portfolio/README.md` | current | Product-storytelling workspace that explains what portfolio evidence should exist and why. |
+| `docs/INFORME_TECNICO_SPRINT_3.md` | historical | Older sprint narrative kept for historical context, not current operating truth. |
+
+## Navigation rules
+
+- Deeper leaves stay behind their nearest hub document so the main navigation does not go past `docs/{doc}.md` or `docs/{category}/{doc}.md`.
+- Portfolio sub-docs are entered through `docs/portfolio/README.md`, not listed directly from this top-level hub.
+- If a document stops matching current code or operations, downgrade it to `reference` or `historical` instead of overstating confidence.

--- a/tests/batch1-docs-hygiene-reapply.test.ts
+++ b/tests/batch1-docs-hygiene-reapply.test.ts
@@ -67,23 +67,25 @@ const rootReadmeRequiredCollections = [
 	'admin_audit_logs',
 ] as const
 
-const docsReadmeCurrentDocs = [
-	'docs/ARQUITECTURA.md',
-	'docs/runbooks/production-hardening.md',
-	'docs/runbooks/dependency-risk-note.md',
-	'docs/runbooks/rollback-flags.md',
-	'docs/runbooks/offline-replay-drill.md',
-	'docs/runbooks/admin-cost-smoke-checklist.md',
-	'docs/runbooks/seo-ai-seo-validation-checklist.md',
-	'docs/portfolio/README.md',
+const docsReadmeQuadrantHeadings = [
+	'## Tutorials',
+	'## How-to guides',
+	'## Reference',
+	'## Explanation',
 ] as const
 
-const docsReadmeHistoricalDocs = [
-	'docs/MANUAL_USUARIO.md',
-	'docs/MANUAL_INSTALACION.md',
-	'docs/INFORME_TECNICO_SPRINT_3.md',
-	'docs/ESTRUCTURA_PROYECTO.md',
+const docsReadmeRequiredStatusRows = [
+	'| `docs/MANUAL_USUARIO.md` | historical |',
+	'| `docs/runbooks/production-hardening.md` | current |',
+	'| `docs/runbooks/rollback-flags.md` | current |',
+	'| `docs/ARQUITECTURA.md` | current |',
+	'| `docs/runbooks/otp-operational-policy.md` | current |',
+	'| `docs/portfolio/README.md` | current |',
+	'| `docs/INFORME_TECNICO_SPRINT_3.md` | historical |',
 ] as const
+
+const allowedDocsReadmeStatuses = new Set(['current', 'reference', 'historical'])
+const docsPathPattern = /`(docs\/[^`]+\.md)`/g
 
 interface PackageJsonShape {
 	scripts?: Record<string, string>
@@ -118,6 +120,26 @@ function readPackageScripts(): Record<string, string> {
 	) as PackageJsonShape
 
 	return packageJson.scripts ?? {}
+}
+
+function extractDocsMarkdownPaths(markdown: string): string[] {
+	return Array.from(markdown.matchAll(docsPathPattern), ([, path]) => path).filter(
+		(path) => !path.includes('{'),
+	)
+}
+
+function docsReadmePathIsHubLevel(path: string): boolean {
+	const segments = path.split('/')
+
+	return segments.length === 2 || segments.length === 3
+}
+
+function extractDocsReadmeTableStatuses(markdown: string): string[] {
+	return markdown
+		.split('\n')
+		.map((line) => line.trim())
+		.filter((line) => line.startsWith('| `docs/') && line.endsWith(' |'))
+		.map((line) => line.split('|').map((cell) => cell.trim())[2])
 }
 
 	describe('batch 1 docs and hygiene reapply', () => {
@@ -157,7 +179,7 @@ function readPackageScripts(): Record<string, string> {
 
 		expect(rootReadme.includes('## Runtime Surfaces')).toBe(true)
 		expect(rootReadme.includes('## Not yet reapplied in this workflow')).toBe(false)
-		expect(docsReadme.includes('despues de Batch 1 solamente')).toBe(false)
+		expect(docsReadme.includes('## Current / usable hoy')).toBe(false)
 		expect(docsReadme.includes('## Planned / later batches')).toBe(false)
 		expect(diagramGuide.includes('## Suggested source of truth')).toBe(true)
 	})
@@ -191,18 +213,16 @@ function readPackageScripts(): Record<string, string> {
 
 	it('keeps docs README aligned with the integrated current-vs-historical contract', () => {
 		const docsReadme = readFileSync(join(cleanRoot, 'docs/README.md'), 'utf8')
+		const referencedDocsPaths = extractDocsMarkdownPaths(docsReadme)
+		const statusMarkers = extractDocsReadmeTableStatuses(docsReadme)
 
-		expect(docsReadme.includes('## Current / usable hoy')).toBe(true)
+		expect(docsReadmeQuadrantHeadings.filter((heading) => !docsReadme.includes(heading))).toEqual([])
+		expect(docsReadmeRequiredStatusRows.filter((row) => !docsReadme.includes(row))).toEqual([])
+		expect(docsReadme).toContain('`docs/{doc}.md` or `docs/{category}/{doc}.md`')
+		expect(referencedDocsPaths.filter((path) => !docsReadmePathIsHubLevel(path))).toEqual([])
 		expect(
-			docsReadmeCurrentDocs.filter(
-				(relativePath) => !docsReadme.includes(`| \`${relativePath}\` | Current |`),
-			),
+			referencedDocsPaths.filter((path) => !existsSync(join(cleanRoot, path))),
 		).toEqual([])
-		expect(
-			docsReadmeHistoricalDocs.filter(
-				(relativePath) =>
-					!docsReadme.includes(`| \`${relativePath}\` | Historical |`),
-			),
-		).toEqual([])
+		expect(statusMarkers.filter((status) => !allowedDocsReadmeStatuses.has(status))).toEqual([])
 	})
 })


### PR DESCRIPTION
Closes #41

## Summary
- Establish the documentation overhaul foundation with an English Diátaxis hub.
- Keep top-level docs navigation shallow so later portfolio/media/reference slices can land without bloating the hub.
- Update the docs hygiene regression test to lock the new hub contract.

## Changes
| File | Change |
|------|--------|
| `docs/README.md` | Replaces the legacy Spanish state index with an English Diátaxis documentation hub and navigation rules. |
| `tests/batch1-docs-hygiene-reapply.test.ts` | Validates quadrant headings, lowercase status markers, valid links, and hub-only top-level navigation. |

## Testing
- [x] `bun test tests/batch1-docs-hygiene-reapply.test.ts`
- [x] `bun test`

## Review notes
- SDD change: `portfolio-product-documentation-overhaul`
- Slice: 1 / docs IA foundation
- Diff size: 2 files, 71 insertions / 69 deletions
- Out of scope: ADR extraction, Firebase/Vercel references, media assets, HyperFrames videos, external validation evidence

## Checklist
- [x] Linked an approved issue
- [x] Added exactly one type label
- [x] Docs updated
- [x] Conventional commit format
- [x] Preserved local `opencode.json` untracked