### PR TITLE
docs(portfolio): add api reference

### DIFF
--- a/docs/.extraction-sources.md
+++ b/docs/.extraction-sources.md
@@ -11,3 +11,4 @@ This batch records safe file-level extraction for `portfolio-product-documentati
 | `docs/adr/0005-offline-consent-queue-and-sync-ledger.md` | `docs/english-ia-overhaul` | `6e5a3de` | `04c41a4797e8da84a484d47439e297a53ee4921c` | `2026-05-24` |
 | `docs/adr/README.md` | `docs/english-ia-overhaul` | `6e5a3de` | `cc8d2dcb44d841abe5c50718c85db4dd00aeed48` | `2026-05-24` |
 | `scripts/render-diagrams.ts` | `docs/english-ia-overhaul` | `6e5a3de` | `357b47da5c59bbd289075427ddcf0ad7e467ecdd` | `2026-05-24` |
+| `docs/reference/api.md` | `docs/english-ia-overhaul` | `6e5a3de` | `515fe4b8ae9f17ee5f5259f8dd4a34ff632d3bc4` | `2026-05-24` |

--- a/docs/README.md
+++ b/docs/README.md
@@ -38,6 +38,7 @@ No current tutorial is published yet. This hub keeps the IA ready for future tut
 | `docs/reference/architecture.md` | current | English reference architecture — system planes, data flow, collection contracts, and operational gates. |
 | `docs/reference/firebase.md` | current | Firebase configuration, Firestore collections, security rules, indexes, auth/OTP flow, and storage rules. |
 | `docs/reference/deploy-and-ci.md` | current | Deploy & CI reference — Vercel model, CI jobs, Lighthouse gates, and operational notes. |
+| `docs/reference/api.md` | current | API reference — every route, method, auth requirement, validation schema, and service path. |
 | `docs/ARQUITECTURA.md` | current | Current architecture narrative, rollout model, and cross-surface system map. |
 | `docs/runbooks/otp-operational-policy.md` | current | OTP runtime values, lockouts, and source-linked operational contract. |
 | `docs/runbooks/dependency-risk-note.md` | current | Current dependency risk position and accepted residual tooling debt. |

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -1,0 +1,120 @@
+# API Reference
+
+> **Status**: current
+> **Audit date**: 2026-05-24
+> **Diátaxis**: Reference
+> **Linked sources**: `src/app/api/*/route.ts` (32 route handlers), `src/services/` (13 service files), `src/lib/schemas/` (6 schema files)
+
+Manual source map of the Jumping Park API surface. Use this reference to find the shortest truthful path from a route handler to its service, validation contract, or schema helper.
+
+## 1. Quick path
+
+1. Start in **Route surface** (§3) to find the public, kiosk, or admin endpoint.
+2. Jump to **Service layer** (§2) to see which file owns the behavior.
+3. Check **Validation surface** (§4) when the request body or stored content is shaped by Zod.
+4. For local development verification, run `bun test` (the project's Bun test runner with 158+ test assertions).
+
+## 2. Service layer
+
+13 service files under `src/services/`. Every route delegates business logic to one of these.
+
+| File | Primary exports | Consumed by | Owns |
+|---|---|---|---|
+| `src/services/authService.ts` | `requestOtpChallenge`, `validateOtpChallengeRequest`, `verifyOtpSession`, OTP helpers | `POST /api/otp`, `POST /api/otp/validate`, `POST /api/consentimientos`, `GET /api/usuarios/[uid]/menores` | OTP challenge lifecycle, permissive/strict validation, short-lived access sessions. |
+| `src/services/rateLimitService.ts` | `checkRateLimit` | Indirect via `authService.ts` | Firestore-backed rate-limit buckets for OTP request throttling. |
+| `src/services/emailService.ts` | `sendOtpEmail`, `sendConsentEmail` | Indirect via `authService.ts`; `POST /api/admin/consents/[id]/resend` | Resend integration for OTP delivery and manual consent resend. |
+| `src/services/consentService.ts` | `consentService`, asset helpers | `POST /api/consentimientos`, `GET /api/settings/consent`, `GET /api/admin/verificar-consentimiento`, `GET/DELETE /api/admin/consents/[id]`, `GET /api/admin/consents/[id]/pdf` | Consent creation, signature storage access, lookups, validity checks, and consent-settings reads. |
+| `src/services/pdfService.ts` | `generateConsentPdf` | `GET /api/admin/consents/[id]/pdf`, `POST /api/admin/consents/[id]/resend` | On-demand branded consent PDF generation. |
+| `src/services/minorIndexService.ts` | `minorIndexService` | `GET /api/usuarios/[uid]/menores`, `POST/GET /api/admin/migrate/minors`, indirect via `consentService.ts` | Denormalized `minors_index` read model, sync logic, and migration helpers. |
+| `src/services/userService.ts` | `userService`, `staffService`, `minorService` | `/api/admin/users*`, `/api/admin/staff*`, `/api/admin/minors*` | Visitor, staff, and admin-minor listing/detail/delete, plus staff creation and permission checks. |
+| `src/services/adminSessionService.ts` | `exchangeAdminSessionFromIdToken`, `refreshAdminSessionFromRequest` | `/api/admin/session` | Admin cookie-session exchange and refresh on top of Firebase ID tokens. |
+| `src/services/adminMetricsService.ts` | `adminMetricsService`, aggregate builders | `/api/admin/stats`, `/api/admin/stats/detailed`, `/api/admin/activity` | Aggregate and live admin metrics, detailed KPI rollups, and activity snapshots. |
+| `src/services/adminConsentListService.ts` | `listAdminConsents`, `buildAdminConsentsListResponse` | `GET /api/admin/consents` | Paginated admin consent listing with search, cursor support, and freshness metadata. |
+| `src/services/adminExportService.ts` | `buildUsersCsvExport`, `buildConsentsCsvExport` | `/api/admin/export/users`, `/api/admin/export/consents` | CSV payload generation for users and consents. |
+| `src/services/exportRangeService.ts` | `resolveExportRange`, `resolveBoundedExportRange`, export metadata helpers | `/api/admin/export/users`, `/api/admin/export/consents` | Export date-range hardening, bounded-range validation, and response headers. |
+| `src/services/adminAuditService.ts` | Audit entry builders and writers | `/api/admin/users/[id]`, `/api/admin/users/[id]/permissions`, `/api/admin/staff*`, `/api/admin/minors/[id]`, `/api/admin/settings/consent`, `/api/admin/roles` | Audit-log payload construction plus single-write and batch-write helpers for admin mutations. |
+
+## 3. Route surface
+
+### 3.1 Public & kiosk endpoints
+
+| Route | Methods | Auth | Validation → Service | Notes |
+|---|---|---|---|---|
+| `/api/otp` | `POST` | None (rate-limited per IP) | `sendOtpSchema` → `requestOtpChallenge` | Starts OTP challenge; applies hardening/rate-limit policy. |
+| `/api/otp/validate` | `POST` | None | `validateOtpSchema` → `validateOtpChallengeRequest` | Verifies 6-digit code; opens short-lived OTP access session. |
+| `/api/consentimientos` | `POST` | OTP session cookie | `consentSubmissionSchema` → `verifyOtpSession` + `consentService.createConsent` | Creates public consent record after OTP gate passes. |
+| `/api/settings/consent` | `GET` | None | `consentService.getConsentSettings` | Reads localized consent content with Firestore-first, default-content fallback. |
+| `/api/usuarios` | `GET`, `POST` | POST: none; GET: none | `createCrudRoutes` + `usuarioCreateSchema` | Generic Firestore CRUD wrapper for user documents. |
+| `/api/usuarios/check` | `POST` | None | Route-local Zod parse + Firestore lookup | Blind-check; returns only masked email metadata. |
+| `/api/usuarios/[uid]/menores` | `GET` | OTP session cookie | `verifyOtpSession` + `minorIndexService.getMinorsByParentId` | Parent-facing minor lookup after OTP session validation. |
+| `/api/menores` | `GET`, `POST` | None | `createCrudRoutes` + `menorCreateSchema` | Generic CRUD wrapper for standalone minors. |
+| `/api/accesos` | `GET`, `POST` | None | `createCrudRoutes` + `accesoCreateSchema` | Generic CRUD wrapper for access logs. |
+
+### 3.2 Admin endpoints
+
+| Route group | Methods | Auth | Primary service/helper | Notes |
+|---|---|---|---|---|
+| `/api/admin/session` | `GET`, `POST`, `DELETE` | Firebase ID token (POST) / session cookie (GET, DELETE) | `adminSessionService` + `adminAuth` cookie helpers | Exchanges Firebase ID tokens for admin cookies, refreshes them, clears on logout. |
+| `/api/admin/verificar-consentimiento` | `GET` | Admin session cookie | `consentService.findConsentByCedula` | Verifies whether a document ID maps to a valid consent. |
+| `/api/admin/users`, `/api/admin/users/recent`, `/api/admin/users/[id]`, `/api/admin/users/[id]/permissions` | `GET`, `DELETE`, `PATCH` | Admin session cookie | `userService` + `adminAuditService` | Admin visitor lookup, recent-user view, deletion, and custom-permission mutation. |
+| `/api/admin/staff`, `/api/admin/staff/[id]` | `GET`, `POST`, `DELETE` | Admin session cookie | `staffService` + `adminAuditService` | Staff listing, creation, lookup, and removal. |
+| `/api/admin/minors`, `/api/admin/minors/[id]`, `/api/admin/migrate/minors` | `GET`, `DELETE`, `POST` | Admin session cookie | `minorService`, `minorIndexService`, `adminAuditService` | Admin minor listing/detail/delete plus migration path into `minors_index`. |
+| `/api/admin/consents`, `/api/admin/consents/[id]`, `/api/admin/consents/[id]/pdf`, `/api/admin/consents/[id]/resend` | `GET`, `DELETE`, `POST` | Admin session cookie | `adminConsentListService`, `consentService`, `pdfService`, `emailService`, `adminAuditService` | Consent list/detail/delete plus on-demand PDF generation and manual resend. |
+| `/api/admin/export/users`, `/api/admin/export/consents` | `GET` | Admin session cookie | `exportRangeService` + `adminExportService` | CSV export routes with bounded-range hardening metadata. |
+| `/api/admin/stats`, `/api/admin/stats/detailed`, `/api/admin/activity` | `GET` | Admin session cookie | `adminMetricsService` | Overview KPIs, detailed period rollups, and same-day activity snapshots. |
+| `/api/admin/settings/consent` | `GET`, `POST`, `DELETE` | Admin session cookie | Route-local Firestore settings orchestration + `adminAuditService` | Admin authoring surface for consent-copy settings; no dedicated service wrapper yet. |
+| `/api/admin/roles` | `GET`, `POST`, `DELETE` | Admin session cookie | Route-local admin/user management + `adminAuditService` | Role management; most orchestration inside the route handler. |
+| `/api/admin/set-admin` | `POST` | Env-guarded | Route-local Firebase Admin/Auth orchestration | Emergency/admin-bootstrap endpoint; toggled by environment variables. |
+
+### 3.3 Route handler patterns
+
+All route handlers follow one of two patterns:
+
+- **Service-driven**: thin route handler that validates input via `apiHandler` / `getValidatedBody`, then delegates to a service function. Example: `POST /api/otp` → `requestOtpChallenge`.
+- **Route-local orchestration**: keeps request parsing and Firestore operations inside the route file itself. Currently used by `/api/admin/settings/consent`, `/api/admin/roles`, `/api/admin/set-admin`, and `/api/usuarios/check`.
+
+## 4. Validation surface
+
+### 4.1 Route-entry schemas
+
+Six Zod contracts gate the main public CRUD/auth submission routes.
+
+| Schema | File | Used by | Validates |
+|---|---|---|---|
+| `sendOtpSchema` | `src/lib/schemas/auth.schema.ts` | `POST /api/otp` | OTP request: email and/or document ID. |
+| `validateOtpSchema` | `src/lib/schemas/auth.schema.ts` | `POST /api/otp/validate` | OTP validation: 6-digit code + email/document ID. |
+| `usuarioCreateSchema` | `src/lib/schemas/crud.schema.ts` | `POST /api/usuarios` | Direct visitor/user creation payloads. |
+| `menorCreateSchema` | `src/lib/schemas/crud.schema.ts` | `POST /api/menores` | Standalone minor creation, built on `minorSchema`. |
+| `accesoCreateSchema` | `src/lib/schemas/crud.schema.ts` | `POST /api/accesos` | Access-log writes for park entry/exit records. |
+| `consentSubmissionSchema` | `src/lib/schemas/consent.schema.ts` | `POST /api/consentimientos` | Public consent: adult identity, minors, signature, optional offline replay metadata. |
+
+### 4.2 Supporting shared/domain validators
+
+| Contract | File | Role |
+|---|---|---|
+| `minorSchema`, `birthDateSchema`, `consentSchema`, `getConsentSchema` | `src/lib/schemas/consent.schema.ts` | Shared minor and consent-form validation reused underneath the public consent flow and CRUD extension points. |
+| `localizedConsentSchema` | `src/lib/schemas/legalContent.schema.ts` | Structural validation for localized legal-content documents stored under settings data. |
+| `visitorSchema` | `src/lib/schemas/visitor.schema.ts` | Visitor-form validation for UI flows; not gating a direct API route today. |
+| `UTF8_NAME_REGEX`, `ALPHANUMERIC_DOC_REGEX` | `src/lib/schemas/shared.regex.ts` | Shared regex primitives used by multiple Zod schemas for document-ID and UTF-8 name rules. |
+
+## 5. Auth model
+
+| Layer | Mechanism | Source |
+|---|---|---|
+| **Public OTP** | Email or document-ID → 6-digit code → short-lived access session cookie | `src/app/api/otp/route.ts`, `src/services/authService.ts` |
+| **Admin session** | Firebase ID token → server-side cookie exchange (`ADMIN_SESSION_COOKIE_NAME`) | `src/app/api/admin/session/route.ts`, `src/services/adminSessionService.ts` |
+| **Custom claims** | Firebase Auth custom claims for RBAC (`admin`, `trabajador`) | `src/lib/adminAuth.ts`, `src/types/auth.ts` |
+| **Rate limiting** | Firestore-backed buckets: max 3 OTP requests / 5 min per email; IP multiplier of 3 | `src/services/rateLimitService.ts`, `src/app/api/otp/route.ts` lines 10-11 |
+
+## 6. What is not centralized yet
+
+- `src/app/api/usuarios/check/route.ts` owns its own schema and Firestore lookup instead of delegating to a service.
+- `/api/admin/settings/consent`, `/api/admin/roles`, and `/api/admin/set-admin` keep meaningful request parsing and orchestration inside the route file.
+- The schema layer is stronger than the documentation/export layer: validation exists, but OpenAPI generation does not.
+- No dedicated service wrapper exists yet for the admin settings consent route.
+
+## 7. Next step
+
+- Read [`docs/reference/architecture.md`](../reference/architecture.md) for the broader rollout, Firebase, and admin-surface context behind these endpoints.
+- Read [`docs/reference/firebase.md`](../reference/firebase.md) for collection contracts, security rules, and the auth/OTP flow in detail.
+- Run `bun test` before changing route handlers or service contracts to catch regressions quickly.

--- a/tests/batch1-docs-hygiene-reapply.test.ts
+++ b/tests/batch1-docs-hygiene-reapply.test.ts
@@ -817,4 +817,221 @@ function extractDocsReadmeTableStatuses(markdown: string): string[] {
 		// Verify actual config matches — consent route is in lighthouserc.json, not lighthouse.yml
 		expect(lighthouseConfig).toContain('consentimiento-digital')
 	})
+
+	// --- Slice 6: API reference ---
+
+	const apiDocPath = 'docs/reference/api.md'
+
+	const apiRequiredSections = [
+		'## 1. Quick path',
+		'## 2. Service layer',
+		'## 3. Route surface',
+		'## 4. Validation surface',
+		'## 5. Auth model',
+	]
+
+	const apiRequiredServiceFiles = [
+		'src/services/authService.ts',
+		'src/services/rateLimitService.ts',
+		'src/services/emailService.ts',
+		'src/services/consentService.ts',
+		'src/services/pdfService.ts',
+		'src/services/minorIndexService.ts',
+		'src/services/userService.ts',
+		'src/services/adminSessionService.ts',
+		'src/services/adminMetricsService.ts',
+		'src/services/adminConsentListService.ts',
+		'src/services/adminExportService.ts',
+		'src/services/exportRangeService.ts',
+		'src/services/adminAuditService.ts',
+	]
+
+	const apiRequiredRoutePaths = [
+		'/api/otp',
+		'/api/otp/validate',
+		'/api/consentimientos',
+		'/api/settings/consent',
+		'/api/usuarios',
+		'/api/usuarios/check',
+		'/api/usuarios/[uid]/menores',
+		'/api/menores',
+		'/api/accesos',
+		'/api/admin/session',
+		'/api/admin/verificar-consentimiento',
+		'/api/admin/users',
+		'/api/admin/users/recent',
+		'/api/admin/users/[id]',
+		'/api/admin/users/[id]/permissions',
+		'/api/admin/staff',
+		'/api/admin/staff/[id]',
+		'/api/admin/minors',
+		'/api/admin/minors/[id]',
+		'/api/admin/migrate/minors',
+		'/api/admin/consents',
+		'/api/admin/consents/[id]',
+		'/api/admin/consents/[id]/pdf',
+		'/api/admin/consents/[id]/resend',
+		'/api/admin/export/users',
+		'/api/admin/export/consents',
+		'/api/admin/stats',
+		'/api/admin/stats/detailed',
+		'/api/admin/activity',
+		'/api/admin/settings/consent',
+		'/api/admin/roles',
+		'/api/admin/set-admin',
+	]
+
+	const apiRequiredSchemaFiles = [
+		{ file: 'src/lib/schemas/auth.schema.ts', schema: 'sendOtpSchema' },
+		{ file: 'src/lib/schemas/auth.schema.ts', schema: 'validateOtpSchema' },
+		{ file: 'src/lib/schemas/crud.schema.ts', schema: 'usuarioCreateSchema' },
+		{ file: 'src/lib/schemas/crud.schema.ts', schema: 'menorCreateSchema' },
+		{ file: 'src/lib/schemas/crud.schema.ts', schema: 'accesoCreateSchema' },
+		{ file: 'src/lib/schemas/consent.schema.ts', schema: 'consentSubmissionSchema' },
+		{ file: 'src/lib/schemas/consent.schema.ts', schema: 'minorSchema' },
+		{ file: 'src/lib/schemas/consent.schema.ts', schema: 'birthDateSchema' },
+		{ file: 'src/lib/schemas/legalContent.schema.ts', schema: 'localizedConsentSchema' },
+		{ file: 'src/lib/schemas/visitor.schema.ts', schema: 'visitorSchema' },
+		{ file: 'src/lib/schemas/shared.regex.ts', schema: 'ALPHANUMERIC_DOC_REGEX' },
+		{ file: 'src/lib/schemas/shared.regex.ts', schema: 'UTF8_NAME_REGEX' },
+	]
+
+	it('keeps the API reference doc present and truthful', () => {
+		const apiDoc = readFileSync(join(cleanRoot, apiDocPath), 'utf8')
+
+		expect(apiDoc.startsWith('# API Reference\n')).toBe(true)
+		expect(apiDoc).toContain('> **Status**: current')
+		expect(apiDoc).toContain('> **Diátaxis**: Reference')
+		expect(apiDoc).toContain('> **Audit date**:')
+
+		for (const section of apiRequiredSections) {
+			expect(apiDoc).toContain(section)
+		}
+
+		// Every claimed service file must exist on disk
+		for (const serviceFile of apiRequiredServiceFiles) {
+			expect(existsSync(join(cleanRoot, serviceFile))).toBe(true)
+		}
+
+		// Every claimed route must appear in the doc
+		for (const routePath of apiRequiredRoutePaths) {
+			expect(apiDoc).toContain(routePath)
+		}
+
+		// Every claimed schema file must exist and the schema name must appear in the doc
+		for (const { file, schema } of apiRequiredSchemaFiles) {
+			expect(existsSync(join(cleanRoot, file))).toBe(true)
+			expect(apiDoc).toContain(schema)
+		}
+
+		// Auth model section must describe both auth layers
+		expect(apiDoc).toContain('Public OTP')
+		expect(apiDoc).toContain('Admin session')
+		expect(apiDoc).toContain('Custom claims')
+		expect(apiDoc).toContain('Rate limiting')
+	})
+
+	it('keeps API reference doc linked from hub as current reference', () => {
+		const docsReadme = readFileSync(join(cleanRoot, 'docs/README.md'), 'utf8')
+
+		expect(docsReadme).toContain('| `docs/reference/api.md` | current |')
+		expect(docsReadme).toContain('API reference')
+	})
+
+	it('verifies API doc cross-references architecture and firebase docs', () => {
+		const apiDoc = readFileSync(join(cleanRoot, apiDocPath), 'utf8')
+
+		// Must link to architecture reference for broader context
+		expect(apiDoc).toContain('](../reference/architecture.md)')
+
+		// Must link to firebase reference for collection/auth details
+		expect(apiDoc).toContain('](../reference/firebase.md)')
+	})
+
+	it('verifies API doc internal links resolve to existing files', () => {
+		const apiDoc = readFileSync(join(cleanRoot, apiDocPath), 'utf8')
+
+		const docLinkPattern = /\((\.\.\/|docs\/)[^)]+\.md\)/g
+		for (const [link] of apiDoc.matchAll(docLinkPattern)) {
+			const path = link.slice(1, -1)
+			const apiDocDir = join(cleanRoot, 'docs', 'reference')
+			const resolvedPath = path.startsWith('../')
+				? join(apiDocDir, path)
+				: join(cleanRoot, path)
+			expect(existsSync(resolvedPath)).toBe(true)
+		}
+	})
+
+	// --- Triangulation: verify API doc route claims match real route files ---
+
+	const publicRouteDirs = [
+		'api/otp',
+		'api/otp/validate',
+		'api/consentimientos',
+		'api/settings/consent',
+		'api/usuarios',
+		'api/usuarios/check',
+		'api/usuarios/[uid]/menores',
+		'api/menores',
+		'api/accesos',
+	] as const
+
+	const adminRouteDirs = [
+		'api/admin/session',
+		'api/admin/verificar-consentimiento',
+		'api/admin/users',
+		'api/admin/users/recent',
+		'api/admin/users/[id]',
+		'api/admin/users/[id]/permissions',
+		'api/admin/staff',
+		'api/admin/staff/[id]',
+		'api/admin/minors',
+		'api/admin/minors/[id]',
+		'api/admin/migrate/minors',
+		'api/admin/consents',
+		'api/admin/consents/[id]',
+		'api/admin/consents/[id]/pdf',
+		'api/admin/consents/[id]/resend',
+		'api/admin/export/users',
+		'api/admin/export/consents',
+		'api/admin/stats',
+		'api/admin/stats/detailed',
+		'api/admin/activity',
+		'api/admin/settings/consent',
+		'api/admin/roles',
+		'api/admin/set-admin',
+	] as const
+
+	it('verifies every public route file exists on disk', () => {
+		for (const routeDir of publicRouteDirs) {
+			const routeFile = join(cleanRoot, 'src', 'app', routeDir, 'route.ts')
+			expect(existsSync(routeFile)).toBe(true)
+		}
+	})
+
+	it('verifies every admin route directory has a route.ts file', () => {
+		for (const dir of adminRouteDirs) {
+			const routeFile = join(cleanRoot, 'src', 'app', dir, 'route.ts')
+			expect(existsSync(routeFile)).toBe(true)
+		}
+	})
+
+	it('verifies API doc auth model references match actual source files', () => {
+		const apiDoc = readFileSync(join(cleanRoot, apiDocPath), 'utf8')
+
+		// Auth source files must exist and be mentioned
+		const authFiles = [
+			'src/app/api/otp/route.ts',
+			'src/services/authService.ts',
+			'src/app/api/admin/session/route.ts',
+			'src/services/adminSessionService.ts',
+			'src/lib/adminAuth.ts',
+			'src/types/auth.ts',
+			'src/services/rateLimitService.ts',
+		]
+		for (const file of authFiles) {
+			expect(existsSync(join(cleanRoot, file))).toBe(true)
+			expect(apiDoc).toContain(file)
+		}
+	})
 })


### PR DESCRIPTION
Closes #53

## Summary
- Add a truthful API reference mapped to the real route, service, schema, and auth surfaces.
- Link the API reference from the docs hub and record extraction provenance.
- Extend docs regression tests to verify route/service/schema/auth claims against the real source tree.

## Changes
| File | Change |
|------|--------|
| `docs/reference/api.md` | Adds the API reference for route groups, service layers, validation schemas, and auth models. |
| `docs/README.md` | Registers the API reference in the Reference quadrant. |
| `docs/.extraction-sources.md` | Records provenance for the extracted API reference slice. |
| `tests/batch1-docs-hygiene-reapply.test.ts` | Adds API reference truthfulness and link-integrity assertions. |

## Testing
- [x] `bun test tests/batch1-docs-hygiene-reapply.test.ts`
- [x] Fresh SDD review for Slice 6 passed

## Review notes
- SDD change: `portfolio-product-documentation-overhaul`
- Slice: 6 / API reference
- Diff size: ~320 lines
- Out of scope: screenshots, HyperFrames, external validation evidence

## Checklist
- [x] Linked an approved issue
- [x] Added exactly one type label
- [x] Docs updated
- [x] Conventional commit format
- [x] Preserved local `opencode.json` untracked/excluded