### PR TITLE
docs(portfolio): add getting started guide

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,3 +132,6 @@ public/worker-*.js.map
 # Local verification screenshots (not product assets)
 block-e-consentimiento-digital.png
 block-e-kiosk-consent-dialog.png
+
+# SDD deferred work slices
+_deferred/

--- a/docs/.extraction-sources.md
+++ b/docs/.extraction-sources.md
@@ -12,3 +12,5 @@ This batch records safe file-level extraction for `portfolio-product-documentati
 | `docs/adr/README.md` | `docs/english-ia-overhaul` | `6e5a3de` | `cc8d2dcb44d841abe5c50718c85db4dd00aeed48` | `2026-05-24` |
 | `scripts/render-diagrams.ts` | `docs/english-ia-overhaul` | `6e5a3de` | `357b47da5c59bbd289075427ddcf0ad7e467ecdd` | `2026-05-24` |
 | `docs/reference/api.md` | `docs/english-ia-overhaul` | `6e5a3de` | `515fe4b8ae9f17ee5f5259f8dd4a34ff632d3bc4` | `2026-05-24` |
+| `docs/guides/getting-started.md` | `docs/english-ia-overhaul` | `6e5a3de` | `0cbb45985fb5d6468df735a38fe57efbd2a576d6` | `2026-05-24` |
+<!-- Deployment and testing guide extraction sources deferred to _deferred/slice-7b-deployment and _deferred/slice-7c-testing -->

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,10 +12,9 @@ This is the entry point for the current documentation information architecture (
 
 ## Tutorials
 
-No current tutorial is published yet. This hub keeps the IA ready for future tutorials without inventing content that does not exist in the repo today.
-
 | Path | Status | Role |
 | --- | --- | --- |
+| `docs/guides/getting-started.md` | current | Contributor-first walkthrough: clone → install → boot → verify. |
 | `docs/MANUAL_USUARIO.md` | historical | Legacy end-user walkthrough kept only for traceability. |
 
 ## How-to guides

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -1,0 +1,136 @@
+# Getting started
+
+> **Status**: current
+> **Diátaxis**: Tutorial
+> **Audit date**: 2026-05-24
+
+This guide gets a contributor from clone to a real local walkthrough of the active Jumping Park surfaces. Use it when you need the shortest truthful path to install dependencies, configure the required services, boot the app, and verify that the public, kiosk, and admin entrypoints respond.
+
+## Quick path
+
+1. Install dependencies with `bun install`.
+2. Copy `.env.example` to `.env.local` with `cp .env.example .env.local` and fill the Firebase, Resend, and admin-session values.
+3. Start the app with `bun dev`.
+4. Open `http://localhost:3000/`, `http://localhost:3000/consentimiento-digital`, and `http://localhost:3000/admin/login`.
+5. Run `bun test` and `bun run check:types` before you hand the slice to someone else.
+
+## Before you start
+
+- **Runtime**: Bun is the package manager, script runner, and test runner for this repository.
+- **Framework**: The app runs on Next.js 16 + React 19.
+- **Required services**: Firebase (Auth + Firestore + Storage) and Resend.
+- **Admin testing**: If you want to log into the admin surface, create the user in Firebase Auth first.
+- **Current UI reality**: The documentation canon is English, but many in-app labels and flows still render Spanish copy. That is current implementation, not a docs bug.
+
+## Local setup
+
+### 1. Install dependencies
+
+```bash
+bun install
+```
+
+### 2. Create `.env.local`
+
+```bash
+cp .env.example .env.local
+```
+
+Fill the required values from your Firebase project, Resend account, and local admin-session policy:
+
+| Variable | Why it matters |
+| --- | --- |
+| `FIREBASE_PROJECT_ID` | Server-side Firebase Admin bootstrap. |
+| `FIREBASE_CLIENT_EMAIL` | Firebase Admin service account identity. |
+| `FIREBASE_PRIVATE_KEY` | Firebase Admin private key (`\n` must stay escaped inside `.env.local`). |
+| `FIREBASE_STORAGE_BUCKET` | Signature and PDF storage bucket. |
+| `NEXT_PUBLIC_FIREBASE_API_KEY` | Browser Firebase bootstrap for auth-enabled surfaces. |
+| `NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN` | Firebase Auth domain for browser sign-in flows. |
+| `NEXT_PUBLIC_FIREBASE_PROJECT_ID` | Browser-visible Firebase project identifier. |
+| `NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET` | Browser-visible storage bucket configuration. |
+| `NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID` | Browser Firebase app wiring. |
+| `NEXT_PUBLIC_FIREBASE_APP_ID` | Browser Firebase app wiring. |
+| `RESEND_API_KEY` | Email delivery for OTP and consent-related mail flows. |
+| `ADMIN_JWT_SECRET` | Protects the admin session cookie/bearer flow. |
+
+Recommended explicit local defaults already shown in `.env.example`:
+
+- `ADMIN_SESSION_MODE=dual`
+- `ADMIN_IDLE_TIMEOUT_MINUTES=30`
+- `OTP_EXPIRATION_MINUTES=60`
+- `OTP_SESSION_DURATION_MINUTES=120`
+- `OTP_LOCKOUT_MINUTES=15`
+- `OTP_HARDENING_ENABLED=true`
+- `EXPORT_BOUNDS_ENFORCED=true`
+- `PUBLIC_SEO_ENABLED=false`
+
+Optional local-only helpers:
+
+- `ALLOW_ADMIN_SETUP=false`
+- `ADMIN_SECRET_KEY=`
+- `FIRESTORE_EMULATOR_HOST=`
+- `FIREBASE_SERVICE_ACCOUNT_KEY=`
+
+Restart `bun dev` after any env or flag change.
+
+### 3. Start the application
+
+```bash
+bun dev
+```
+
+The default local entrypoint is `http://localhost:3000/`.
+
+## First-run walkthrough
+
+### 1. Check the public route
+
+Open `http://localhost:3000/consentimiento-digital`.
+
+You should see the public SEO/AI-SEO surface that explains the consent flow before a visitor arrives at the park. This is the shareable public route, not the admin or kiosk UI.
+
+### 2. Check the kiosk route
+
+Open `http://localhost:3000/`.
+
+This is the kiosk landing surface. From there, the visitor flow continues into `/ingreso`, `/otp`, `/registro`, `/consentimiento`, and `/exito`. The full OTP flow requires working Firebase + Resend configuration because the app sends and validates real access codes.
+
+### 3. Check the admin route
+
+Open `http://localhost:3000/admin/login`.
+
+If you need a local admin account:
+
+1. Create or reuse a user in Firebase Auth.
+2. Run `bun run set-admin <email> admin`.
+3. Sign out and sign back in after the claim update.
+
+The target user must already exist in Firebase Auth.
+
+### 4. Know the first-run boundaries
+
+- The root route can redirect an already-authenticated admin to `/admin/usuarios`.
+- The admin surface depends on Firebase Auth plus the custom-claim role assignment.
+- Kiosk and public routes are safe first checks when you only want to validate boot + routing.
+
+## Verification
+
+Run the smallest useful checks after the first boot:
+
+```bash
+bun test
+bun run check:types
+```
+
+Use this checklist before you call the local setup healthy:
+
+- [ ] `bun dev` starts without missing-env crashes.
+- [ ] `http://localhost:3000/` loads the kiosk landing page.
+- [ ] `http://localhost:3000/consentimiento-digital` loads the public explainer route.
+- [ ] `http://localhost:3000/admin/login` renders the admin login screen.
+
+## Next step
+
+- Read `docs/runbooks/production-hardening.md` for the operational validation path.
+- Read `docs/runbooks/rollback-flags.md` before enabling or disabling rollout flags.
+- Read `CONTRIBUTING.md` for the current quality-gate map before opening a PR.

--- a/tests/docs-getting-started-guide.test.ts
+++ b/tests/docs-getting-started-guide.test.ts
@@ -1,0 +1,113 @@
+import { existsSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'bun:test'
+
+const projectRoot = process.cwd()
+
+function readProjectFile(relativePath: string): string {
+	return readFileSync(join(projectRoot, relativePath), 'utf8')
+}
+
+describe('getting started guide stays truthful', () => {
+	const guidePath = 'docs/guides/getting-started.md'
+
+	it('exists and has required sections', () => {
+		expect(existsSync(join(projectRoot, guidePath))).toBe(true)
+
+		const guide = readProjectFile(guidePath)
+
+		expect(guide).toContain('# Getting started')
+		expect(guide).toContain('> **Status**: current')
+		expect(guide).toContain('> **Diátaxis**: Tutorial')
+		expect(guide).toContain('## Quick path')
+		expect(guide).toContain('## Before you start')
+		expect(guide).toContain('## Local setup')
+		expect(guide).toContain('## First-run walkthrough')
+		expect(guide).toContain('## Verification')
+	})
+
+	it('keeps the setup commands, env requirements, and first-run routes aligned with the current repository', () => {
+		const guide = readProjectFile(guidePath)
+
+		// Setup commands
+		expect(guide).toContain('bun install')
+		expect(guide).toContain('cp .env.example .env.local')
+		expect(guide).toContain('bun dev')
+		expect(guide).toContain('bun test')
+		expect(guide).toContain('bun run check:types')
+
+		// Env var references
+		expect(guide).toContain('FIREBASE_PROJECT_ID')
+		expect(guide).toContain('NEXT_PUBLIC_FIREBASE_API_KEY')
+		expect(guide).toContain('RESEND_API_KEY')
+		expect(guide).toContain('ADMIN_JWT_SECRET')
+
+		// Admin setup
+		expect(guide).toContain('bun run set-admin <email> admin')
+		expect(guide).toContain('The target user must already exist in Firebase Auth.')
+
+		// First-run routes
+		expect(guide).toContain('http://localhost:3000/')
+		expect(guide).toContain('http://localhost:3000/consentimiento-digital')
+		expect(guide).toContain('http://localhost:3000/admin/login')
+
+		// Cross-references
+		expect(guide).toContain('docs/runbooks/production-hardening.md')
+		expect(guide).toContain('docs/runbooks/rollback-flags.md')
+		expect(guide).toContain('CONTRIBUTING.md')
+	})
+
+	it('references env vars that exist in .env.example', () => {
+		const guide = readProjectFile(guidePath)
+		const envExample = readProjectFile('.env.example')
+
+		const envVars = [
+			'ADMIN_SESSION_MODE',
+			'OTP_EXPIRATION_MINUTES',
+			'OTP_SESSION_DURATION_MINUTES',
+			'OTP_LOCKOUT_MINUTES',
+			'OTP_HARDENING_ENABLED',
+			'EXPORT_BOUNDS_ENFORCED',
+			'PUBLIC_SEO_ENABLED',
+		]
+
+		for (const envVar of envVars) {
+			expect(guide).toContain(envVar)
+			expect(envExample).toContain(envVar)
+		}
+	})
+
+	it('references routes that have real page files on disk', () => {
+		const guide = readProjectFile(guidePath)
+
+		// Verify route page files exist
+		const routeChecks = [
+			{ url: '/consentimiento-digital', file: 'src/app/(public)/consentimiento-digital/page.tsx' },
+			{ url: '/admin/login', file: 'src/app/(admin)/admin/login/page.tsx' },
+		]
+
+		for (const { url, file } of routeChecks) {
+			expect(guide).toContain(url)
+			expect(existsSync(join(projectRoot, file))).toBe(true)
+		}
+	})
+
+	it('references scripts that exist in package.json', () => {
+		const guide = readProjectFile(guidePath)
+		const packageJson = JSON.parse(readProjectFile('package.json')) as {
+			scripts?: Record<string, string>
+		}
+		const scripts = packageJson.scripts ?? {}
+
+		// set-admin script
+		expect(guide).toContain('bun run set-admin')
+		expect(scripts['set-admin']).toBeDefined()
+
+		// Bun dev is standard
+		expect(guide).toContain('bun dev')
+		expect(scripts.dev).toBeDefined()
+	})
+})
+
+// Deployment guide tests deferred to _deferred/slice-7b-deployment/docs-deployment-guide.test.ts
+// Testing guide tests deferred to _deferred/slice-7c-testing/docs-testing-guide.test.ts


### PR DESCRIPTION
Closes #55

## Summary
- Add the getting-started guide as the first contributor/tutorial-style guide in the new docs system.
- Link it from the docs hub and record extraction provenance.
- Add focused regression tests that verify commands, env vars, page routes, and guide truthfulness.

## Changes
| File | Change |
|------|--------|
| `docs/guides/getting-started.md` | Adds the getting-started guide for clone → install → configure → boot → verify. |
| `docs/README.md` | Registers the guide in the Tutorials quadrant. |
| `docs/.extraction-sources.md` | Records provenance for the extracted guide slice. |
| `tests/docs-getting-started-guide.test.ts` | Adds focused guide truthfulness and link checks. |
| `.gitignore` | Ignores local `_deferred/` recovery workspace used during the guide re-slice. |

## Testing
- [x] `bun test tests/docs-getting-started-guide.test.ts`
- [x] Fresh SDD review for Slice 7A passed

## Review notes
- SDD change: `portfolio-product-documentation-overhaul`
- Slice: 7A / getting started guide
- Diff size: ~251 lines
- Out of scope: deployment guide, testing guide, media work, external validation evidence

## Checklist
- [x] Linked an approved issue
- [x] Added exactly one type label
- [x] Docs updated
- [x] Conventional commit format
- [x] Preserved local `opencode.json` untracked/excluded