### PR TITLE
docs(portfolio): add testing guide

### DIFF
--- a/docs/.extraction-sources.md
+++ b/docs/.extraction-sources.md
@@ -14,4 +14,4 @@ This batch records safe file-level extraction for `portfolio-product-documentati
 | `docs/reference/api.md` | `docs/english-ia-overhaul` | `6e5a3de` | `515fe4b8ae9f17ee5f5259f8dd4a34ff632d3bc4` | `2026-05-24` |
 | `docs/guides/getting-started.md` | `docs/english-ia-overhaul` | `6e5a3de` | `0cbb45985fb5d6468df735a38fe57efbd2a576d6` | `2026-05-24` |
 | `docs/guides/deployment.md` | `docs/english-ia-overhaul` | `6e5a3de` | `356ddb5fde492725aef99db173e484a3463210e8` | `2026-05-24` |
-<!-- Testing guide extraction source deferred to _deferred/slice-7c-testing -->
+| `docs/guides/testing.md` | `docs/english-ia-overhaul` | `6e5a3de` | `3a035c56d6395fbedac820f2e382d2e67102c5de` | `2026-05-30` |

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,6 +22,7 @@ This is the entry point for the current documentation information architecture (
 | Path | Status | Role |
 | --- | --- | --- |
 | `docs/guides/deployment.md` | current | Truthful deploy path: Firebase prep → Vercel config → post-deploy smoke. |
+| `docs/guides/testing.md` | current | Testing pyramid, tooling map, CI integration, and pre-merge verification checklist. |
 | `docs/runbooks/production-hardening.md` | current | Main operator path for release validation, rollout, and rollback checks. |
 | `docs/runbooks/rollback-flags.md` | current | Flag-by-flag rollback procedure for staged releases. |
 | `docs/runbooks/offline-replay-drill.md` | current | Step-by-step offline replay validation drill. |

--- a/docs/guides/testing.md
+++ b/docs/guides/testing.md
@@ -1,0 +1,77 @@
+# Testing guide
+
+> **Status**: current
+> **Diátaxis**: How-to
+> **Audit date**: 2026-05-24
+
+This guide explains which verification layers exist in Jumping Park today, when to run them, and how they connect to CI. Use it when you need the shortest truthful path from a local code change to the same quality gates the repository enforces in automation.
+
+## Quick path
+
+1. Run `bun test` for the default regression pass.
+2. Run `bun run check` before you hand work to review.
+3. If you changed public or kiosk UI behavior, run `bun run playwright:install` once on the machine and then `bun run test:a11y:e2e`.
+4. If the change can affect production build behavior, run `bun run build`.
+
+## Testing pyramid
+
+| Layer | What lives here today | How to run it | When to use it |
+| --- | --- | --- | --- |
+| Foundation — unit and contract tests | Most automated coverage lives in `tests/*.test.ts*`, including service logic, route handlers, configuration helpers, rollout policy checks, and documentation contracts such as `tests/batch1-docs-hygiene-reapply.test.ts` and `tests/docs-getting-started-guide.test.ts`. | `bun test` or `bun test tests/<file>.test.ts` | Default for almost every slice. Start here first because it is fast and already matches the repo's main test runner. |
+| Middle — route and service behavior with injected dependencies | The repo exercises many multi-step behaviors inside the same Bun layer by creating `NextRequest` objects, injecting fake dependencies, and asserting real outputs (for example `tests/consent-route.test.ts` and `tests/admin-session-service.test.ts`). There is no separate `test:integration` script in this repository today. | `bun test tests/<file>.test.ts` | Use this when the behavior crosses parsing, validation, service calls, or response mapping but does not need a browser. |
+| Top — browser accessibility smoke | Playwright + Axe smoke coverage lives in `playwright/accessibility.a11y.ts` and currently verifies `/consentimiento-digital`, `/ingreso`, and the kiosk consent dialog flow. | `bun run test:a11y:e2e` | Use this when you touch rendering, keyboard flow, hydration stability, or accessibility-sensitive UI. |
+
+The pyramid is intentionally bottom-heavy today: Bun tests carry most regression coverage, and browser automation is still a focused smoke layer rather than a full end-to-end matrix.
+
+## Tooling map
+
+| Need | Command | Notes |
+| --- | --- | --- |
+| Run the default automated regression pass | `bun test` | This is the canonical test command from `package.json`. |
+| Run one file during TDD or slice verification | `bun test tests/<file>.test.ts` | Fastest loop for docs contracts, services, and route handlers. |
+| Get a coverage snapshot | `bun test --coverage` | Useful when you add new logic and want a quick signal about untested branches. |
+| Run all static quality gates together | `bun run check` | Expands to `check:format && check:lint && check:types && audit`. |
+| Inspect the format gate directly | `bun run check:format` | Non-mutating formatter verification via Biome (`biome check src/`). |
+| Inspect the lint gate directly | `bun run check:lint` | Biome lint over `src/`. |
+| Inspect the type gate directly | `bun run check:types` | `tsc --noEmit`. |
+| Inspect repository audits directly | `bun run audit` | Runs dead-code, duplicate-code, and circular-dependency checks. |
+| Install Playwright browsers on a fresh machine | `bun run playwright:install` | Needed before the first local browser smoke run. |
+| Run the browser accessibility smoke suite | `bun run test:a11y:e2e` | Uses `playwright.config.ts`, starts `bun dev`, and targets `playwright/*.a11y.ts`. |
+| Match CI build verification locally | `bun run build` | Good follow-up when the change can affect Next.js build output or env wiring. |
+
+## CI integration
+
+### Main CI workflow
+
+`.github/workflows/ci.yml` is the primary automation entrypoint for pushes to `main`/`master` and for pull requests.
+
+| Job | What it does | Why it matters locally |
+| --- | --- | --- |
+| `quality` | Runs `bun install --frozen-lockfile`, prepares placeholder secrets/env values, then runs `bun run check` and `bun test`. | Your local minimum parity path is `bun run check` + `bun test`. |
+| `dependency-audit` | Runs `bun audit` and only blocks when the report includes a direct runtime dependency vulnerability. | If audit noise appears locally, distinguish direct dependency risk from tooling/transitive noise before escalating it. |
+| `build-verification` | Waits for quality + audit to pass, injects build placeholders, then runs `bun run build`. | Run a local build when you change env handling, routing, metadata, or server/client boundaries. |
+
+### Lighthouse workflow
+
+`.github/workflows/lighthouse.yml` is a separate pull-request workflow. It builds the app and runs `bun x lhci autorun --config=./lighthouserc.json`, then uploads the Lighthouse reports artifact.
+
+That workflow complements testing, but it is not a substitute for `bun test` or the Playwright accessibility smoke layer.
+
+### Current boundary to remember
+
+- `bun run test:a11y:e2e` exists and is valuable, but it is **not** part of `.github/workflows/ci.yml` today.
+- Browser coverage is intentionally narrow and should be expanded carefully instead of being described as full E2E parity.
+- Placeholder Firebase/Auth/Resend values in CI prove wiring and buildability, not live-service correctness.
+
+## Before you merge
+
+- [ ] Run `bun test`.
+- [ ] Run `bun run check`.
+- [ ] Run `bun run build` if the slice can affect build output, routing, env wiring, or metadata.
+- [ ] Run `bun run test:a11y:e2e` if you changed public or kiosk UI behavior.
+- [ ] Use `bun test --coverage` when you add new logic and want a quick signal about untested branches.
+
+## Next step
+
+- Read `docs/guides/getting-started.md` if you still need the local bootstrapping path.
+- Read `docs/runbooks/production-hardening.md` when you are validating release readiness instead of day-to-day contributor checks.

--- a/tests/docs-testing-guide.test.ts
+++ b/tests/docs-testing-guide.test.ts
@@ -1,0 +1,115 @@
+import { existsSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'bun:test'
+
+const projectRoot = process.cwd()
+
+function readProjectFile(relativePath: string): string {
+	return readFileSync(join(projectRoot, relativePath), 'utf8')
+}
+
+describe('testing guide stays truthful', () => {
+	const guidePath = 'docs/guides/testing.md'
+
+	it('exists and has required sections', () => {
+		expect(existsSync(join(projectRoot, guidePath))).toBe(true)
+
+		const guide = readProjectFile(guidePath)
+
+		expect(guide).toContain('# Testing guide')
+		expect(guide).toContain('> **Status**: current')
+		expect(guide).toContain('> **Diátaxis**: How-to')
+		expect(guide).toContain('## Quick path')
+		expect(guide).toContain('## Testing pyramid')
+		expect(guide).toContain('## Tooling map')
+		expect(guide).toContain('## CI integration')
+		expect(guide).toContain('## Before you merge')
+	})
+
+	it('references package.json scripts that actually exist', () => {
+		const guide = readProjectFile(guidePath)
+		const pkg = JSON.parse(readProjectFile('package.json')) as { scripts: Record<string, string> }
+		const scripts = pkg.scripts
+
+		const scriptNames = [
+			'test',
+			'check',
+			'check:format',
+			'check:lint',
+			'check:types',
+			'audit',
+			'build',
+			'playwright:install',
+			'test:a11y:e2e',
+		]
+
+		for (const name of scriptNames) {
+			if (guide.includes(`bun run ${name}`) || guide.includes(`\`bun run ${name}\``) || guide.includes(`\`bun ${name}\``)) {
+				expect(scripts[name]).toBeDefined()
+			}
+		}
+	})
+
+	it('references CI workflow jobs that match actual ci.yml', () => {
+		const guide = readProjectFile(guidePath)
+		const ciYml = readProjectFile('.github/workflows/ci.yml')
+
+		expect(guide).toContain('.github/workflows/ci.yml')
+
+		const ciJobs = ['quality', 'dependency-audit', 'build-verification']
+		for (const job of ciJobs) {
+			expect(guide).toContain(job)
+			expect(ciYml).toContain(`${job}:`)
+		}
+	})
+
+	it('references Lighthouse workflow that matches actual file', () => {
+		const guide = readProjectFile(guidePath)
+
+		expect(guide).toContain('.github/workflows/lighthouse.yml')
+		expect(existsSync(join(projectRoot, '.github/workflows/lighthouse.yml'))).toBe(true)
+		expect(guide).toContain('lighthouserc.json')
+		expect(existsSync(join(projectRoot, 'lighthouserc.json'))).toBe(true)
+	})
+
+	it('references test files that exist on disk', () => {
+		const guide = readProjectFile(guidePath)
+
+		const testFiles = [
+			'tests/batch1-docs-hygiene-reapply.test.ts',
+			'tests/docs-getting-started-guide.test.ts',
+			'tests/consent-route.test.ts',
+			'tests/admin-session-service.test.ts',
+		]
+
+		for (const file of testFiles) {
+			if (guide.includes(file)) {
+				expect(existsSync(join(projectRoot, file))).toBe(true)
+			}
+		}
+	})
+
+	it('accurately describes the a11y test boundary', () => {
+		const guide = readProjectFile(guidePath)
+		const ciYml = readProjectFile('.github/workflows/ci.yml')
+
+		expect(guide).toContain('playwright/accessibility.a11y.ts')
+		expect(existsSync(join(projectRoot, 'playwright/accessibility.a11y.ts'))).toBe(true)
+
+		// Must correctly scope coverage to public and kiosk, not admin.
+		expect(guide).toContain('public or kiosk UI behavior')
+		expect(guide).not.toContain('public, kiosk, or admin UI behavior')
+
+		// Must correctly state the command is not part of the current CI workflow.
+		expect(guide).toContain('not')
+		expect(guide).toContain('ci.yml')
+		expect(ciYml).not.toContain('test:a11y:e2e')
+	})
+
+	it('cross-references other guides and runbooks correctly', () => {
+		const guide = readProjectFile(guidePath)
+
+		expect(guide).toContain('docs/guides/getting-started.md')
+		expect(guide).toContain('docs/runbooks/production-hardening.md')
+	})
+})


### PR DESCRIPTION
Closes #59

## Summary
- Add the testing guide as the next how-to slice in the docs system.
- Link it from the docs hub and record extraction provenance.
- Add focused contract tests that verify scripts, CI jobs, Lighthouse references, and key test-file boundaries against the real repository.

## Changes
| File | Change |
|------|--------|
| `docs/guides/testing.md` | Adds the testing guide for quality gates, focused suites, CI context, and current a11y boundary. |
| `docs/README.md` | Registers the testing guide in the How-to quadrant. |
| `docs/.extraction-sources.md` | Records provenance for the extracted testing guide slice. |
| `tests/docs-testing-guide.test.ts` | Adds focused testing-guide truthfulness and link checks. |

## Testing
- [x] `bun test tests/docs-testing-guide.test.ts`
- [x] Fresh SDD review for Slice 7C passed

## Review notes
- SDD change: `portfolio-product-documentation-overhaul`
- Slice: 7C / testing guide
- Diff size: ~188 lines
- Out of scope: media work, external validation evidence

## Checklist
- [x] Linked an approved issue
- [x] Added exactly one type label
- [x] Docs updated
- [x] Conventional commit format
- [x] Preserved local `opencode.json` untracked/excluded