### PR TITLE
docs(portfolio): add screenshot capture schema foundation

### DIFF
--- a/docs/.extraction-sources.md
+++ b/docs/.extraction-sources.md
@@ -18,3 +18,4 @@ This batch records safe file-level extraction for `portfolio-product-documentati
 | `tests/docs-content-integrity.test.ts` | `docs/english-ia-overhaul` (adapted) | `6e5a3de` | `c539f7d7` (adr-log), `a052e54d` (contributor-boundaries), `a592c375` (diagram-tooling), `9768a135` (ia-index) | `2026-05-30` |
 | `scripts/optimize-screenshots.ts` | `docs/english-ia-overhaul` | `6e5a3de` | `32a2c24835d986c46c0459213525e954b36c7190` | `2026-05-31` |
 | `tests/docs-screenshot-tooling.test.ts` | `docs/english-ia-overhaul` (adapted) | `6e5a3de` | `10cea0a01e4f87b57de95e18ecb9c649de71ac19` | `2026-05-31` |
+| `src/lib/schemas/screenshotCapture.schema.ts` | (new in this slice, 5.2-A) | — | Zod schema paired with the default capture plan and aligned with the `*.schema.ts` naming convention | `2026-06-01` |

--- a/docs/portfolio/screenshots/capture-config.md
+++ b/docs/portfolio/screenshots/capture-config.md
@@ -1,0 +1,65 @@
+# Screenshot capture config schema
+
+> **Status**: current
+> **Diátaxis**: Reference
+> **Audit date**: 2026-06-01
+
+The Zod schema `screenshotCaptureConfigSchema` (in
+`src/lib/schemas/screenshotCapture.schema.ts`) is the single source of truth for
+the screenshot capture plan. The orchestrator parses every user override
+through this schema before any browser is launched, so the shape below is
+the contract between the config, the script, and the optimizer.
+
+## Shape
+
+```text
+type CaptureSurface = "kiosk" | "admin" | "public";
+
+type CaptureJob = {
+	id: string;            // 1..64 chars, unique across the plan
+	surface: CaptureSurface;
+	route: string;         // must start with "/"
+	headingMatcher?: string;
+	viewport: { width: 320..3840, height: 240..2160 };
+	fileName: string;      // lowercase kebab-case, e.g. "kiosk-ingreso"
+};
+
+type ScreenshotCaptureConfig = {
+  outputDir: string;
+  baseUrl: string;       // must be a valid URL
+  timeoutMs?: 1000..120000; // default 15_000
+  jobs: CaptureJob[];    // 1..64 entries
+};
+```
+
+`fileName` is the PNG stem the optimizer (`scripts/optimize-screenshots.ts`)
+reuses for the WebP asset (e.g. `kiosk-ingreso` →
+`kiosk-ingreso.png` → `kiosk-ingreso.webp`).
+
+## Default plan
+
+`DEFAULT_CAPTURE_PLAN` mirrors every currently required still in
+[`README.md`](./README.md), excluding the optional `kiosk-offline-success`
+capture that only lands when that runtime exists:
+
+| id | surface | route |
+| --- | --- | --- |
+| `kiosk-ingreso` | kiosk | `/ingreso` |
+| `kiosk-otp` | kiosk | `/otp` |
+| `kiosk-consentimiento` | kiosk | `/consentimiento` |
+| `admin-dashboard` | admin | `/admin` |
+| `admin-consents-list` | admin | `/admin/consentimientos` |
+| `public-consentimiento-digital` | public | `/consentimiento-digital` |
+
+`DEFAULT_CAPTURE_CONFIG` writes to `docs/portfolio/screenshots` and points
+at `http://127.0.0.1:3000`. Viewport defaults are `1280x900` for kiosk and
+public, `1440x900` for admin.
+
+## What this slice does NOT do
+
+- It does not run any capture. The orchestrator and CLI are a follow-up
+  slice (`_deferred/slice-5.2-orchestrator/`).
+- It does not commit real PNGs. Captures only land when the orchestrator
+  lands.
+- It does not add a `screenshot:capture` script entry. That wiring lands
+  with the orchestrator so a non-existent script is never exposed.

--- a/src/lib/schemas/screenshotCapture.schema.ts
+++ b/src/lib/schemas/screenshotCapture.schema.ts
@@ -1,0 +1,160 @@
+/**
+ * Screenshot capture configuration schema.
+ *
+ * Shared between the future screenshot capture orchestrator and any
+ * tooling that needs to validate a capture plan. Each job describes one still
+ * capture: which surface to open, what viewport to use, and where to write the
+ * resulting PNG.
+ *
+ * The optimizer (`scripts/optimize-screenshots.ts`) consumes the same
+ * `outputDir` to convert PNGs into WebP, so the two scripts stay coordinated
+ * through this schema instead of magic strings.
+ */
+
+import { z } from "zod";
+
+export const CAPTURE_SURFACE = {
+	KIOSK: "kiosk",
+	ADMIN: "admin",
+	PUBLIC: "public",
+} as const;
+
+export type CaptureSurface =
+	(typeof CAPTURE_SURFACE)[keyof typeof CAPTURE_SURFACE];
+
+const SURFACE_VALUES = [
+	CAPTURE_SURFACE.KIOSK,
+	CAPTURE_SURFACE.ADMIN,
+	CAPTURE_SURFACE.PUBLIC,
+] as const;
+
+const FILE_NAME_REGEX = /^[a-z0-9][a-z0-9-]*[a-z0-9]$/;
+
+/**
+ * A single capture job. The `route` is the in-app path the Playwright harness
+ * will open; `viewport` is a literal pixel size so captures stay deterministic
+ * across runs; `fileName` is the PNG stem the optimizer will reuse for the
+ * WebP asset (e.g. `kiosk-ingreso` -> `kiosk-ingreso.png` -> `kiosk-ingreso.webp`).
+ */
+export const captureJobSchema = z.object({
+	id: z.string().min(1).max(64),
+	surface: z.enum(SURFACE_VALUES),
+	route: z.string().min(1).max(2048).startsWith("/"),
+	headingMatcher: z.string().min(1).max(256).optional(),
+	viewport: z.object({
+		width: z.number().int().min(320).max(3840),
+		height: z.number().int().min(240).max(2160),
+	}),
+	fileName: z.string().regex(FILE_NAME_REGEX, {
+		message:
+			"fileName must be lowercase, dash-separated, and start/end with alphanumeric",
+	}),
+});
+
+export type CaptureJob = z.infer<typeof captureJobSchema>;
+
+/**
+ * Top-level capture configuration. `outputDir` is the directory the capture
+ * script writes PNGs to; it is the same directory the optimizer reads from.
+ */
+export const screenshotCaptureConfigSchema = z
+	.object({
+		outputDir: z.string().min(1),
+		baseUrl: z.string().url(),
+		timeoutMs: z.number().int().min(1000).max(120_000).default(15_000),
+		jobs: z.array(captureJobSchema).min(1).max(64),
+	})
+	.superRefine((config, context) => {
+		const seenIds = new Set<string>();
+		const seenFileNames = new Set<string>();
+
+		for (const [index, job] of config.jobs.entries()) {
+			if (seenIds.has(job.id)) {
+				context.addIssue({
+					code: z.ZodIssueCode.custom,
+					message: "jobs must use unique id values",
+					path: ["jobs", index, "id"],
+				});
+			}
+			seenIds.add(job.id);
+
+			if (seenFileNames.has(job.fileName)) {
+				context.addIssue({
+					code: z.ZodIssueCode.custom,
+					message: "jobs must use unique fileName values",
+					path: ["jobs", index, "fileName"],
+				});
+			}
+			seenFileNames.add(job.fileName);
+		}
+	});
+
+export type ScreenshotCaptureConfig = z.infer<
+	typeof screenshotCaptureConfigSchema
+>;
+
+/**
+ * Default capture plan derived from `docs/portfolio/screenshots/README.md`.
+ *
+ * The plan is intentionally hand-curated: the goal is to produce a small set
+ * of truthful stills, not to enumerate every possible screen. Each entry
+ * mirrors a row in the portfolio checklist so the manifest and the plan can
+ * be diffed without guessing.
+ */
+export const DEFAULT_CAPTURE_PLAN: CaptureJob[] = [
+	{
+		id: "kiosk-ingreso",
+		surface: CAPTURE_SURFACE.KIOSK,
+		route: "/ingreso",
+		headingMatcher: "ingreso",
+		viewport: { width: 1280, height: 900 },
+		fileName: "kiosk-ingreso",
+	},
+	{
+		id: "kiosk-otp",
+		surface: CAPTURE_SURFACE.KIOSK,
+		route: "/otp",
+		headingMatcher: "otp",
+		viewport: { width: 1280, height: 900 },
+		fileName: "kiosk-otp",
+	},
+	{
+		id: "kiosk-consentimiento",
+		surface: CAPTURE_SURFACE.KIOSK,
+		route: "/consentimiento",
+		headingMatcher: "consentimiento",
+		viewport: { width: 1280, height: 900 },
+		fileName: "kiosk-consentimiento",
+	},
+	{
+		id: "admin-dashboard",
+		surface: CAPTURE_SURFACE.ADMIN,
+		route: "/admin",
+		headingMatcher: "dashboard",
+		viewport: { width: 1440, height: 900 },
+		fileName: "admin-dashboard",
+	},
+	{
+		id: "admin-consents-list",
+		surface: CAPTURE_SURFACE.ADMIN,
+		route: "/admin/consentimientos",
+		headingMatcher: "consentimientos",
+		viewport: { width: 1440, height: 900 },
+		fileName: "admin-consents-list",
+	},
+	{
+		id: "public-consentimiento-digital",
+		surface: CAPTURE_SURFACE.PUBLIC,
+		route: "/consentimiento-digital",
+		headingMatcher: "consentimiento digital",
+		viewport: { width: 1280, height: 900 },
+		fileName: "public-consentimiento-digital",
+	},
+];
+
+export const DEFAULT_CAPTURE_CONFIG: ScreenshotCaptureConfig = {
+	outputDir: "docs/portfolio/screenshots",
+	baseUrl: "http://127.0.0.1:3000",
+	timeoutMs: 15_000,
+	jobs: DEFAULT_CAPTURE_PLAN,
+};

--- a/tests/screenshot-capture-schema.test.ts
+++ b/tests/screenshot-capture-schema.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Screenshot capture config schema — minimal validation.
+ *
+ * Proves the Zod schema accepts the default plan, rejects malformed input,
+ * and that the default plan covers every portfolio checklist id with a
+ * unique file name. The capture orchestrator, CLI, and integration
+ * behaviour live in follow-up slices and stay in
+ * `_deferred/slice-5.2-orchestrator/screenshot-capture-foundation.test.ts.deferred`.
+ */
+
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "bun:test";
+import {
+	CAPTURE_SURFACE,
+	DEFAULT_CAPTURE_CONFIG,
+	DEFAULT_CAPTURE_PLAN,
+	captureJobSchema,
+	screenshotCaptureConfigSchema,
+} from "@/lib/schemas/screenshotCapture.schema";
+
+const PORTFOLIO_SCREENSHOT_IDS = [
+	"kiosk-ingreso",
+	"kiosk-otp",
+	"kiosk-consentimiento",
+	"admin-dashboard",
+	"admin-consents-list",
+	"public-consentimiento-digital",
+] as const;
+
+function expectThrows(fn: () => unknown, pattern: string): void {
+	let caught: unknown = null;
+	try {
+		fn();
+	} catch (error) {
+		caught = error;
+	}
+	expect(caught !== null && caught !== undefined).toBe(true);
+	const errorMessage = caught instanceof Error ? caught.message : JSON.stringify(caught);
+	expect(errorMessage.includes(pattern)).toBe(true);
+}
+
+describe("screenshot capture schema", () => {
+	it("lives at the shared schema path", () => {
+		expect(
+			existsSync(join(process.cwd(), "src/lib/schemas/screenshotCapture.schema.ts")),
+		).toBe(true);
+	});
+
+	it("accepts the default plan and rejects malformed configs", () => {
+		const parsed = screenshotCaptureConfigSchema.parse(DEFAULT_CAPTURE_CONFIG);
+		expect(parsed.jobs.length).toBe(DEFAULT_CAPTURE_PLAN.length);
+		expect(parsed.outputDir).toBe("docs/portfolio/screenshots");
+		expect(parsed.baseUrl).toBe("http://127.0.0.1:3000");
+
+		expectThrows(
+			() =>
+				screenshotCaptureConfigSchema.parse({
+					...DEFAULT_CAPTURE_CONFIG,
+					jobs: [],
+				}),
+			"jobs",
+		);
+		expectThrows(
+			() =>
+				captureJobSchema.parse({
+					id: "job-01",
+					surface: CAPTURE_SURFACE.KIOSK,
+					route: "/ingreso",
+					viewport: { width: 1280, height: 900 },
+					fileName: "Bad-Case",
+				}),
+			"fileName",
+		);
+		expectThrows(
+			() =>
+				captureJobSchema.parse({
+					id: "job-01",
+					surface: CAPTURE_SURFACE.KIOSK,
+					route: "no-leading-slash",
+					viewport: { width: 1280, height: 900 },
+					fileName: "kiosk-ingreso",
+				}),
+			"route",
+		);
+		expectThrows(
+			() =>
+				captureJobSchema.parse({
+					id: "job-01",
+					surface: CAPTURE_SURFACE.KIOSK,
+					route: "/ingreso",
+					viewport: { width: 10, height: 900 },
+					fileName: "kiosk-ingreso",
+				}),
+			"width",
+		);
+		expectThrows(
+			() =>
+				captureJobSchema.parse({
+					id: "job-01",
+					surface: CAPTURE_SURFACE.KIOSK,
+					route: "/ingreso",
+					viewport: { width: 1280, height: 900 },
+					fileName: "a",
+				}),
+			"fileName",
+		);
+
+		expectThrows(
+			() =>
+				screenshotCaptureConfigSchema.parse({
+					...DEFAULT_CAPTURE_CONFIG,
+					jobs: [DEFAULT_CAPTURE_PLAN[0], DEFAULT_CAPTURE_PLAN[0]],
+				}),
+			"unique",
+		);
+	});
+
+	it("covers every portfolio checklist id with a unique file name", () => {
+		const planIds = new Set(DEFAULT_CAPTURE_PLAN.map((job) => job.id));
+		const fileNames = new Set(DEFAULT_CAPTURE_PLAN.map((job) => job.fileName));
+		for (const id of PORTFOLIO_SCREENSHOT_IDS) {
+			expect(planIds.has(id)).toBe(true);
+		}
+		expect(planIds.size).toBe(PORTFOLIO_SCREENSHOT_IDS.length);
+		expect(fileNames.size).toBe(DEFAULT_CAPTURE_PLAN.length);
+	});
+});


### PR DESCRIPTION
Closes #69

## Summary
- Add the screenshot capture schema foundation for the portfolio/media phase.
- Document the schema/default plan contract and record extraction provenance.
- Add focused schema tests for plan validity and naming constraints.

## Changes
| File | Change |
|------|--------|
| `src/lib/schemas/screenshotCapture.ts` | Adds the screenshot capture schema and default plan. |
| `docs/portfolio/screenshots/capture-config.md` | Documents the screenshot capture contract and current default plan. |
| `tests/screenshot-capture-schema.test.ts` | Adds focused schema truthfulness/validation tests. |
| `docs/.extraction-sources.md` | Records provenance for the extracted schema slice. |

## Testing
- [x] `bun test tests/screenshot-capture-schema.test.ts`
- [x] Fresh SDD review for Slice 5.2-A passed

## Review notes
- SDD change: `portfolio-product-documentation-overhaul`
- Slice: 5.2-A / screenshot capture schema foundation
- Diff size: ~319 lines
- Out of scope: screenshot capture orchestrator, real screenshot assets, HyperFrames, CASE_STUDY, external validation evidence

## Checklist
- [x] Linked an approved issue
- [x] Added exactly one type label
- [x] Docs/tooling updated
- [x] Conventional commit format
- [x] Preserved local `opencode.json` untracked/excluded