### PR TITLE
docs(portfolio): add screenshot capture orchestrator

### DIFF
--- a/docs/.extraction-sources.md
+++ b/docs/.extraction-sources.md
@@ -19,3 +19,5 @@ This batch records safe file-level extraction for `portfolio-product-documentati
 | `scripts/optimize-screenshots.ts` | `docs/english-ia-overhaul` | `6e5a3de` | `32a2c24835d986c46c0459213525e954b36c7190` | `2026-05-31` |
 | `tests/docs-screenshot-tooling.test.ts` | `docs/english-ia-overhaul` (adapted) | `6e5a3de` | `10cea0a01e4f87b57de95e18ecb9c649de71ac19` | `2026-05-31` |
 | `src/lib/schemas/screenshotCapture.schema.ts` | (new in this slice, 5.2-A) | — | Zod schema paired with the default capture plan and aligned with the `*.schema.ts` naming convention | `2026-06-01` |
+| `scripts/capture-screenshots.ts` | (new in this slice, 5.2-B) | — | Playwright orchestrator + dry-run + CLI; pairs with `scripts/optimize-screenshots.ts` for PNG → WebP | `2026-06-01` |
+| `docs/portfolio/screenshots/capture-foundation.md` | (new in this slice, 5.2-B) | — | English How-to runbook for the capture pipeline (Diátaxis How-to) | `2026-06-01` |

--- a/docs/portfolio/screenshots/capture-foundation.md
+++ b/docs/portfolio/screenshots/capture-foundation.md
@@ -1,0 +1,120 @@
+# Screenshot capture foundation
+
+> **Status**: foundation only
+> **Diátaxis**: How-to
+> **Audit date**: 2026-06-01
+
+The `scripts/capture-screenshots.ts` orchestrator plus its Zod config
+(`src/lib/schemas/screenshotCapture.schema.ts`) is the foundation for
+the portfolio screenshot pipeline. It pairs with
+`scripts/optimize-screenshots.ts`, which converts the captured PNGs
+into WebP. **This slice establishes the foundation; it does NOT commit
+real captures.**
+
+## Quick path
+
+1. Review the default plan:
+   ```bash
+   bun run screenshot:capture -- --mode dry-run
+   ```
+2. Run the schema regression (current foundation coverage):
+   ```bash
+   bun test tests/screenshot-capture-schema.test.ts
+   ```
+3. When ready to capture for real, follow [Capture runbook](#capture-runbook) below.
+
+## Details
+
+| Topic | Decision |
+| --- | --- |
+| Capture orchestrator | `scripts/capture-screenshots.ts` (Playwright + Zod) |
+| Capture config | `src/lib/schemas/screenshotCapture.schema.ts` (Zod schema, default plan) |
+| Output dir | `docs/portfolio/screenshots/*.png` (default) |
+| Optimizer input | Same dir, consumed by `scripts/optimize-screenshots.ts` |
+| Surface coverage | kiosk, admin, public (see `CAPTURE_SURFACE` const) |
+| Naming | `kebab-case`; the optimizer reuses the stem for the WebP file |
+
+## What this slice does
+
+- Adds a typed capture plan (one row per portfolio checklist entry).
+- Adds a Playwright-based orchestrator that opens a context per job,
+  sets the configured viewport, waits for the heading, and writes a
+  PNG.
+- Adds a `--mode=dry-run` mode that prints the plan and exits 0. This
+  is the safe default; reviewers can confirm scope in PRs without
+  launching a browser.
+- Wires `bun run screenshot:capture` next to the existing
+  `optimize:screenshots` script entry.
+
+## What this slice does NOT do
+
+- It does **not** commit any real capture. PNGs in
+  `docs/portfolio/screenshots/` are placeholders only at this point.
+- It does **not** run end-to-end Playwright captures in CI. The write
+  path requires a live `bun dev` server with demo data; that is a
+  manual step described in the runbook below.
+- It does **not** land the integration regression that exercises the
+  orchestrator's `runCaptureScreenshots` and CLI surface. That test
+  is the next slice (5.2-C, currently in
+  `_deferred/slice-5.2-orchestrator/`).
+- It does **not** touch HyperFrames, demo script, or any of the other
+  Phase 5 media work. Those are separate slices.
+
+## Capture runbook
+
+Use this checklist before committing any real capture to
+`docs/portfolio/screenshots/`:
+
+1. Confirm the dev server is up and demo data is seeded.
+2. Install Playwright Chromium if needed:
+   ```bash
+   bun run playwright:install
+   ```
+3. Run the capture in dry-run to confirm scope:
+   ```bash
+   bun run screenshot:capture -- --mode dry-run
+   ```
+4. Run the capture for real:
+   ```bash
+   bun run screenshot:capture -- --mode write
+   ```
+5. Run the optimizer to produce WebP assets:
+   ```bash
+   bun run optimize:screenshots
+   ```
+6. Manually review each PNG against
+   [`docs/portfolio/screenshots/README.md`](./README.md). Reject any
+   capture that contains real PII, off-screen breadcrumbs, or partial
+   headers.
+7. Update
+   [`docs/portfolio/artifact-manifest.template.md`](../artifact-manifest.template.md)
+   to flip each `pending` row to the asset path once the file lands in
+   the repo.
+
+## Environment blockers
+
+If the environment cannot safely capture (e.g. CI without `bun dev`,
+blocked network for Playwright, missing demo seed), keep the slice
+minimal:
+
+- Do not invent captures. Do not commit empty PNGs.
+- The dry-run command is the truthful evidence the foundation is wired.
+- The schema test (`tests/screenshot-capture-schema.test.ts`) is the
+  truthful evidence the schema accepts the default plan.
+- The orchestrator + CLI integration test lands in slice 5.2-C; until
+  then, dry-run output is the truthful runtime evidence.
+- Document the blocker in the PR description and link the runbook step
+  that will run once the environment recovers.
+
+## Related artifacts
+
+| File | Role |
+| --- | --- |
+| `scripts/capture-screenshots.ts` | Playwright orchestrator + dry-run + CLI |
+| `src/lib/schemas/screenshotCapture.schema.ts` | Zod config schema + default plan |
+| `tests/screenshot-capture-schema.test.ts` | Schema regression (current slice) |
+| `_deferred/slice-5.2-orchestrator/screenshot-capture-foundation.test.ts.deferred` | Orchestrator + CLI integration test (slice 5.2-C) |
+| `scripts/optimize-screenshots.ts` | PNG → WebP optimizer (consumes capture output) |
+| `docs/portfolio/screenshots/README.md` | Portfolio checklist (preserved) |
+| `docs/portfolio/screenshots/capture-config.md` | Schema reference (slice 5.2-A) |
+| `docs/portfolio/artifact-manifest.template.md` | Asset manifest template |

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "migrate:consent-minor-tokens": "bun run scripts/migrate-consent-minor-tokens.ts",
     "migrate:minor-search-tokens": "bun run scripts/migrate-minor-search-tokens.ts",
     "migrate:tildes": "bun run scripts/migrate-search-tokens-tildes.ts",
+    "screenshot:capture": "bun run scripts/capture-screenshots.ts",
     "optimize:images": "bun run scripts/optimize-images.ts",
     "optimize:screenshots": "bun run scripts/optimize-screenshots.ts",
     "backup": "bun run scripts/backup.ts"

--- a/scripts/capture-screenshots.ts
+++ b/scripts/capture-screenshots.ts
@@ -1,0 +1,231 @@
+/**
+ * capture-screenshots — Playwright-based screenshot capture foundation.
+ *
+ * This script is the source-of-truth orchestrator for the portfolio screenshot
+ * pipeline. It pairs with `scripts/optimize-screenshots.ts`, which converts the
+ * PNGs it writes into WebP.
+ *
+ * Pipeline contract:
+ *
+ *   capture-screenshots --mode=write
+ *     -> writes PNGs to `config.outputDir` (default docs/portfolio/screenshots)
+ *   optimize-screenshots --input-dir <config.outputDir>
+ *     -> reads those PNGs and emits WebP into docs/assets/screenshots
+ *
+ * Both scripts share the file-naming convention `kebab-case`; the WebP produced
+ * by the optimizer keeps the same stem (e.g. `kiosk-ingreso.png` becomes
+ * `kiosk-ingreso.webp`).
+ *
+ * Truth gates (this slice):
+ *
+ * 1. Real captures are NOT committed in this slice. The foundation is wired
+ *    and tested, but committing a real capture requires:
+ *      - a running `bun dev` with demo data seeded;
+ *      - an accessible Playwright Chromium browser (already installed by
+ *        `bun run playwright:install`);
+ *      - a manual review pass against the portfolio checklist in
+ *        `docs/portfolio/screenshots/README.md`.
+ * 2. The default mode is `--mode=dry-run`, which prints the resolved plan
+ *    and exits 0. This keeps the script honest in environments where a live
+ *    server is not available, and gives reviewers a single command to see
+ *    what the foundation would do.
+ * 3. When the environment cannot safely capture (e.g. CI without a dev
+ *    server, blocked network for Playwright, missing demo seed), use
+ *    `--mode=dry-run` and the test suite — do not invent captures.
+ */
+
+import { mkdir, writeFile } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
+import { chromium, type Browser } from "@playwright/test";
+import {
+	DEFAULT_CAPTURE_CONFIG,
+	screenshotCaptureConfigSchema,
+	type CaptureJob,
+	type ScreenshotCaptureConfig,
+} from "@/lib/schemas/screenshotCapture.schema";
+
+const projectRoot = resolve(import.meta.dir, "..");
+
+export type CaptureMode = "dry-run" | "write";
+
+export type CaptureRunSummary = {
+	config: ScreenshotCaptureConfig;
+	jobCount: number;
+	written: string[];
+	skipped: string[];
+};
+
+/**
+ * Dependency seam. The default implementation uses Playwright; tests inject a
+ * fake launcher and writer so the foundation can be validated without
+ * launching a real browser.
+ */
+export type CaptureExecutor = {
+	launch: () => Promise<Browser>;
+	writeCapture: (outputPath: string, body: Buffer) => Promise<void>;
+};
+
+export const defaultCaptureExecutor: CaptureExecutor = {
+	async launch() {
+		return chromium.launch({ headless: true });
+	},
+	async writeCapture(outputPath, body) {
+		await mkdir(dirname(outputPath), { recursive: true });
+		await writeFile(outputPath, body);
+	},
+};
+
+export function resolveOutputPath(
+	config: ScreenshotCaptureConfig,
+	job: CaptureJob,
+): string {
+	return join(projectRoot, config.outputDir, `${job.fileName}.png`);
+}
+
+/**
+ * Drive a single capture job. Opens a new context per job so each capture
+ * gets its own viewport and isolated cookies; closes everything in a
+ * finally block so a failed job does not leak the browser process.
+ */
+export async function runCaptureJob(
+	job: CaptureJob,
+	config: ScreenshotCaptureConfig,
+	executor: CaptureExecutor,
+): Promise<{ jobId: string; outputPath: string }> {
+	const outputPath = resolveOutputPath(config, job);
+	const browser = await executor.launch();
+	try {
+		const context = await browser.newContext({
+			viewport: job.viewport,
+		});
+		const page = await context.newPage();
+		try {
+			await page.goto(new URL(job.route, config.baseUrl).toString(), {
+				waitUntil: "domcontentloaded",
+				timeout: config.timeoutMs,
+			});
+			if (job.headingMatcher) {
+				const heading = page
+					.getByRole("heading")
+					.filter({ hasText: new RegExp(job.headingMatcher, "i") })
+					.first();
+				await heading.waitFor({ state: "visible", timeout: config.timeoutMs });
+			}
+			const buffer = await page.screenshot({ fullPage: false });
+			await executor.writeCapture(outputPath, Buffer.from(buffer));
+		} finally {
+			await page.close();
+			await context.close();
+		}
+	} finally {
+		await browser.close();
+	}
+	return { jobId: job.id, outputPath };
+}
+
+/**
+ * Top-level orchestrator. In `dry-run` mode it returns a summary without
+ * touching Playwright or the filesystem. In `write` mode it iterates the
+ * jobs sequentially — captures share a single browser launch per job to
+ * keep resource use predictable.
+ */
+export async function runCaptureScreenshots(options?: {
+	config?: Partial<ScreenshotCaptureConfig>;
+	mode?: CaptureMode;
+	executor?: CaptureExecutor;
+}): Promise<CaptureRunSummary> {
+	const config = screenshotCaptureConfigSchema.parse({
+		...DEFAULT_CAPTURE_CONFIG,
+		...(options?.config ?? {}),
+	});
+	const mode: CaptureMode = options?.mode ?? "dry-run";
+
+	if (mode === "dry-run") {
+		return {
+			config,
+			jobCount: config.jobs.length,
+			written: [],
+			skipped: config.jobs.map((job) => resolveOutputPath(config, job)),
+		};
+	}
+
+	const executor = options?.executor ?? defaultCaptureExecutor;
+	const written: string[] = [];
+	for (const job of config.jobs) {
+		const { outputPath } = await runCaptureJob(job, config, executor);
+		written.push(outputPath);
+	}
+	return {
+		config,
+		jobCount: config.jobs.length,
+		written,
+		skipped: [],
+	};
+}
+
+/**
+ * Render a dry-run report as plain text. Reviewers can run this in PR
+ * threads or in CI logs to confirm the plan.
+ */
+export function formatDryRunReport(summary: CaptureRunSummary): string {
+	const lines: string[] = [];
+	lines.push("[screenshot:capture] dry-run");
+	lines.push(`  baseUrl:   ${summary.config.baseUrl}`);
+	lines.push(`  outputDir: ${summary.config.outputDir}`);
+	lines.push(`  timeoutMs: ${String(summary.config.timeoutMs)}`);
+	lines.push(`  jobs:      ${String(summary.jobCount)}`);
+	for (const job of summary.config.jobs) {
+		const output = resolveOutputPath(summary.config, job);
+		lines.push(
+			`    - [${job.surface}] ${job.id} -> ${job.route} @ ${String(job.viewport.width)}x${String(job.viewport.height)} -> ${output}`,
+		);
+	}
+	return lines.join("\n");
+}
+
+function readCliOption(
+	optionName: "--mode" | "--config" | "--output-dir" | "--base-url",
+): string | undefined {
+	const optionIndex = process.argv.indexOf(optionName);
+	if (optionIndex === -1) return undefined;
+	const value = process.argv[optionIndex + 1];
+	if (!value || value.startsWith("--")) {
+		throw new Error(`Missing value for ${optionName}.`);
+	}
+	return value;
+}
+
+if (import.meta.main) {
+	const modeRaw = readCliOption("--mode") ?? "dry-run";
+	if (modeRaw !== "dry-run" && modeRaw !== "write") {
+		console.error(
+			`[screenshot:capture] unsupported --mode value: ${modeRaw}. Use dry-run or write.`,
+		);
+		process.exit(1);
+	}
+	const outputDir = readCliOption("--output-dir");
+	const baseUrl = readCliOption("--base-url");
+	const configOverride: Partial<ScreenshotCaptureConfig> = {};
+	if (outputDir) configOverride.outputDir = outputDir;
+	if (baseUrl) configOverride.baseUrl = baseUrl;
+
+	runCaptureScreenshots({ mode: modeRaw, config: configOverride })
+		.then((summary) => {
+			if (summary.skipped.length > 0) {
+				console.log(formatDryRunReport(summary));
+				return;
+			}
+			console.log(
+				`[screenshot:capture] wrote ${String(summary.written.length)} capture(s) to ${summary.config.outputDir}.`,
+			);
+			for (const path of summary.written) {
+				console.log(`  - ${path}`);
+			}
+		})
+		.catch((error: unknown) => {
+			console.error(
+				`[screenshot:capture] ${error instanceof Error ? error.message : String(error)}`,
+			);
+			process.exit(1);
+		});
+}


### PR DESCRIPTION
Closes #71

## Summary
- Add the Playwright-based screenshot capture orchestrator and dry-run/write CLI foundation.
- Add the capture foundation runbook and wire `screenshot:capture` into `package.json`.
- Keep this slice limited to orchestration only; no real screenshot assets are committed yet.

## Changes
| File | Change |
|------|--------|
| `scripts/capture-screenshots.ts` | Adds the screenshot capture orchestrator with `dry-run` and `write` modes. |
| `docs/portfolio/screenshots/capture-foundation.md` | Adds the capture foundation runbook and environment blocker guidance. |
| `package.json` | Adds the `screenshot:capture` script. |
| `docs/.extraction-sources.md` | Records provenance for the orchestrator slice. |

## Testing
- [x] `bun run screenshot:capture -- --mode dry-run`
- [x] Fresh SDD review for Slice 5.2-B passed

## Review notes
- SDD change: `portfolio-product-documentation-overhaul`
- Slice: 5.2-B / screenshot capture orchestrator
- Diff size: ~354 lines
- Out of scope: integration test slice 5.2-C, real screenshot assets, HyperFrames, CASE_STUDY, external validation evidence

## Checklist
- [x] Linked an approved issue
- [x] Added exactly one type label
- [x] Docs/tooling updated
- [x] Conventional commit format
- [x] Preserved local `opencode.json` untracked/excluded