### PR TITLE
docs(runbooks): port runbooks to English and update hub per R14

### DIFF
--- a/docs/.extraction-sources.md
+++ b/docs/.extraction-sources.md
@@ -19,3 +19,9 @@ This batch records safe file-level extraction for `portfolio-product-documentati
 | `scripts/optimize-screenshots.ts` | `docs/english-ia-overhaul` | `6e5a3de` | `32a2c24835d986c46c0459213525e954b36c7190` | `2026-05-31` |
 | `tests/docs-screenshot-tooling.test.ts` | `docs/english-ia-overhaul` (adapted) | `6e5a3de` | `10cea0a01e4f87b57de95e18ecb9c649de71ac19` | `2026-05-31` |
 | `src/lib/schemas/screenshotCapture.schema.ts` | (new in this slice, 5.2-A) | — | Zod schema paired with the default capture plan and aligned with the `*.schema.ts` naming convention | `2026-06-01` |
+| `docs/runbooks/production-hardening.md` | `docs/english-ia-overhaul` | `6e5a3de` | R14 hub; English port + 3 added links to `git-history-mp4-purge.md`, `lighthouse-budget-rationale.md`, `otp-operational-policy.md` | `2026-06-01` |
+| `docs/runbooks/offline-replay-drill.md` | `docs/english-ia-overhaul` | `6e5a3de` | R14 drill-down for the offline replay happy path | `2026-06-01` |
+| `docs/runbooks/admin-cost-smoke-checklist.md` | `docs/english-ia-overhaul` | `6e5a3de` | R14 drill-down for admin cursor + aggregate cost smoke | `2026-06-01` |
+| `docs/runbooks/rollback-flags.md` | `docs/english-ia-overhaul` | `6e5a3de` | R14 drill-down for additive-first flag rollbacks | `2026-06-01` |
+| `docs/runbooks/dependency-risk-note.md` | `docs/english-ia-overhaul` | `6e5a3de` | R14 drill-down for `bun audit` residual risk (referenced by hub) | `2026-06-01` |
+| `docs/runbooks/seo-ai-seo-validation-checklist.md` | `docs/english-ia-overhaul` | `6e5a3de` | R14 drill-down for SEO + AI-SEO validation; branch test ref for the non-existent block-b test replaced with `tests/block-e-a11y-smoke.test.tsx` (the only a11y smoke test that exists on main) | `2026-06-01` |

--- a/docs/runbooks/admin-cost-smoke-checklist.md
+++ b/docs/runbooks/admin-cost-smoke-checklist.md
@@ -1,50 +1,50 @@
 # Admin cost smoke checklist
 
-El objetivo de este checklist es verificar que el admin realmente esta operando sobre el plano barato: cursores y agregados, no scans crecientes.
+The goal of this checklist is to prove the admin really stays on the cheaper plane: cursors and aggregates, not growing scans.
 
 ## Preconditions
 
-- `CURSOR_PAGINATION_ENABLED=true` para smoke cursor-first
-- `ADMIN_AGGREGATES_ENABLED=true` para smoke aggregate-first
-- dataset suficiente para navegar mas de una pagina
+- `CURSOR_PAGINATION_ENABLED=true` for the cursor-first smoke.
+- `ADMIN_AGGREGATES_ENABLED=true` for the aggregate-first smoke.
+- A dataset large enough to navigate more than one page.
 
 ## Users / Consents / Minors
 
 ### Cursor contract
 
-- abrir la primera pagina con `limit=20` o `limit=50`;
-- confirmar `pageInfo.hasNextPage` y `pageInfo.nextCursor` cuando existan mas datos;
-- usar `nextCursor` para pedir la siguiente pagina;
-- confirmar que no aparecen signed URLs en listados de consentimientos, solo `signatureStatus`.
+- Open the first page with `limit=20` or `limit=50`.
+- Confirm `pageInfo.hasNextPage` and `pageInfo.nextCursor` when more data exists.
+- Use `nextCursor` to request the next page.
+- Confirm consent lists do not expose signed URLs; they should expose `signatureStatus` only.
 
 ### Search fallback
 
-- ejecutar una busqueda por texto o identificador;
-- confirmar `meta.source = search`;
-- confirmar que el fallback sigue funcional aunque cursor este activo.
+- Run a search by free text or identifier.
+- Confirm `meta.source = search`.
+- Confirm the fallback still works even when cursor pagination is enabled.
 
 ## Dashboard / stats
 
-- llamar `/api/admin/stats` y `/api/admin/stats/detailed?period=month`;
-- confirmar presencia de `freshness.computedAt`;
-- confirmar que la fuente es agregada cuando el flag esta activo;
-- si se usa `recompute=true`, validar que el refresh no rompe el contrato de respuesta.
+- Call `/api/admin/stats` and `/api/admin/stats/detailed?period=month`.
+- Confirm `freshness.computedAt` is present.
+- Confirm the source is aggregated when the flag is enabled.
+- If `recompute=true` is used, verify the refresh does not break the response contract.
 
-## Heuristica de costo
+## Cost heuristic
 
-No estamos midiendo billing real en CI, pero si podemos detectar las senales correctas:
+We are not measuring real billing in CI, but we can still detect the right signals:
 
-- pagina admin: 20-50 items por request, no mas;
-- dashboard: 1-5 documentos agregados, no scans completos;
-- no enrichment de signed URLs por fila;
-- busquedas acotadas por tokens/cursores, no listas completas salvo fallback controlado.
+- Admin page: 20-50 items per request, no more.
+- Dashboard: 1-5 aggregate documents, not full scans.
+- No per-row signed URL enrichment.
+- Searches remain bounded by tokens/cursors, not full list scans except for the controlled fallback.
 
-Si algun query exige un indice nuevo o distinto, no habilitar el flag: primero actualizar IaC y volver a validar contra emulator/query logs.
+If a query needs a new or different index, do not enable the flag yet: update the IaC first, then validate again against emulator/query logs.
 
-## Salida minima
+## Minimum output
 
-- endpoint validado
-- flags activos
-- cursor recibido y reutilizado
-- `freshness` observada
-- conclusion: `PASS`, `PASS WITH NOTES`, o `FAIL`
+- Validated endpoint.
+- Active flags.
+- Cursor received and reused.
+- `freshness` observed.
+- Conclusion: `PASS`, `PASS WITH NOTES`, or `FAIL`.

--- a/docs/runbooks/dependency-risk-note.md
+++ b/docs/runbooks/dependency-risk-note.md
@@ -1,36 +1,36 @@
 # Dependency risk note
 
-## Estado actual
+## Current status
 
-Fecha de referencia: `2026-04-06`
+Reference date: `2026-04-06`
 
-- `next` se actualizo de `16.0.7` a `16.2.2` para sacar del gate las vulnerabilidades directas reportadas por `bun audit`.
-- `firebase` se actualizo de `12.6.0` a `12.11.0` y `firebase-admin` de `13.6.0` a `13.7.0` como upgrade directo de bajo riesgo.
-- Resultado actual: `bun audit` ya no reporta vulnerabilidades en dependencias runtime directas, pero SI mantiene riesgo residual transitive/tooling. Ese es el estado vigente que tienen que repetir `docs/README.md` y `docs/runbooks/production-hardening.md`, sin reinterpretarlo.
+- `next` was updated from `16.0.7` to `16.2.2` to remove the direct vulnerabilities reported by `bun audit` from the gate.
+- `firebase` was updated from `12.6.0` to `12.11.0`, and `firebase-admin` from `13.6.0` to `13.7.0`, as low-risk direct upgrades.
+- Current result: `bun audit` no longer reports vulnerabilities in direct runtime dependencies, but it DOES keep residual transitive/tooling risk. That is the current state that `docs/README.md` and `docs/runbooks/production-hardening.md` must repeat without reinterpretation.
 
-## Riesgo residual aceptado por ahora
+## Residual risk accepted for now
 
-### Runtime transitivo
+### Transitive runtime
 
-- `node-forge`, `jws` y `@tootallnate/once` siguen entrando por el arbol de `firebase-admin` / `@google-cloud/storage`.
-- No se aplico override manual sobre esos paquetes en esta fase para evitar forzar combinaciones no validadas en la cadena Firebase/Admin SDK.
+- `node-forge`, `jws`, and `@tootallnate/once` still enter through the `firebase-admin` / `@google-cloud/storage` tree.
+- No manual override was applied to those packages in this phase because we do not want to force unvalidated combinations into the Firebase/Admin SDK chain.
 
-### Tooling / CI transitivo
+### Transitive tooling / CI
 
 - `smol-toml` via `knip`
 - `ajv`, `brace-expansion`, `minimatch`, `flatted` via `eslint`
-- `picomatch` via `dependency-cruiser`, `knip`, `eslint-config-next` y `jscpd`
+- `picomatch` via `dependency-cruiser`, `knip`, `eslint-config-next`, and `jscpd`
 
-Estos hallazgos afectan principalmente tooling de desarrollo/CI, no el runtime productivo servido a usuarios.
+These findings primarily affect development/CI tooling, not the production runtime served to users.
 
-## Mitigaciones activas
+## Active mitigations
 
-- CI ahora bloquea si `bun audit` vuelve a reportar una vulnerabilidad en una dependencia directa (`(direct dependency)`).
-- El job de audit sigue mostrando el reporte completo para no ocultar deuda transitive/tooling.
-- Los upgrades pendientes deben intentarse primero via releases oficiales upstream; evita overrides agresivos salvo reproduccion controlada y verificacion dedicada.
+- CI now blocks if `bun audit` reports a vulnerability again in a direct dependency (`(direct dependency)`).
+- The audit job still shows the full report so transitive/tooling debt does not get hidden.
+- Pending upgrades should be attempted through official upstream releases first; avoid aggressive overrides unless you have a controlled reproduction and dedicated verification.
 
-## Proximo paso recomendado
+## Recommended next step
 
-1. Revisar releases de `firebase-admin` / `@google-cloud/storage` y retirar este riesgo residual apenas upstream publique rangos parchados.
-2. Re-evaluar si conviene separar tooling vulnerable en jobs no bloqueantes o moverlos a versiones mayores en una fase dedicada de mantenimiento.
-3. Mantener `bun audit` registrado en verify/apply mientras exista este runbook.
+1. Review `firebase-admin` / `@google-cloud/storage` releases and remove this residual risk as soon as upstream publishes patched ranges.
+2. Re-evaluate whether vulnerable tooling should move to non-blocking jobs or to newer major versions in a dedicated maintenance phase.
+3. Keep `bun audit` recorded in verify/apply while this runbook still exists.

--- a/docs/runbooks/dependency-risk-note.md
+++ b/docs/runbooks/dependency-risk-note.md
@@ -4,7 +4,7 @@
 
 Reference date: `2026-04-06`
 
-- `next` was updated from `16.0.7` to `16.2.2` to remove the direct vulnerabilities reported by `bun audit` from the gate.
+- `next` was updated from `16.0.7` to `16.2.6` to remove the direct vulnerabilities reported by `bun audit` from the gate.
 - `firebase` was updated from `12.6.0` to `12.11.0`, and `firebase-admin` from `13.6.0` to `13.7.0`, as low-risk direct upgrades.
 - Current result: `bun audit` no longer reports vulnerabilities in direct runtime dependencies, but it DOES keep residual transitive/tooling risk. That is the current state that `docs/README.md` and `docs/runbooks/production-hardening.md` must repeat without reinterpretation.
 

--- a/docs/runbooks/offline-replay-drill.md
+++ b/docs/runbooks/offline-replay-drill.md
@@ -1,55 +1,55 @@
 # Offline replay drill
 
-Este drill prueba la promesa mas delicada del kiosk: aceptar un consentimiento sin red y reintentar sin duplicar el consecutivo ni crear dos consentimientos.
+This drill tests the kiosk's most delicate promise: accept a consent without network access, then replay it without duplicating the sequence or creating two consents.
 
 ## Preconditions
 
 - `OFFLINE_QUEUE_ENABLED=true`
 - `NEXT_PUBLIC_OFFLINE_QUEUE_ENABLED=true`
-- app reiniciada o redeploy aplicado
-- ambiente con acceso a Firestore para revisar `consents` y `offline_sync`
+- App restarted or redeployed.
+- Environment with Firestore access so you can inspect `consents` and `offline_sync`.
 
-No correr este drill en produccion con los flags por defecto apagados; primero habilitarlo de forma controlada en preview o staging.
+Do not run this drill in production with the default flags disabled; enable it in a controlled preview or staging environment first.
 
-## Flujo de prueba
+## Test flow
 
-1. Abrir el kiosk y completar el flujo hasta la pantalla de consentimiento.
-2. Cortar conectividad del navegador o del dispositivo.
-3. Firmar y enviar el consentimiento.
-4. Confirmar que la UI informa exito diferido y no se cae.
-5. Restaurar conectividad.
-6. Esperar replay automatico o disparar retry manual si el operador lo necesita.
+1. Open the kiosk and complete the flow until the consent screen.
+2. Cut browser or device connectivity.
+3. Sign and submit the consent.
+4. Confirm the UI reports deferred success and does not crash.
+5. Restore connectivity.
+6. Wait for the automatic replay, or trigger a manual retry if the operator needs it.
 
-## Verificaciones esperadas
+## Expected verification
 
-- existe un solo consentimiento final en `consents`;
-- existe `offline_sync/{dedupeKey}` para esa operacion;
-- reintentar el mismo payload no crea un segundo consentimiento;
-- el consecutivo reservado coincide con el ack final;
-- el item de cola sale de `pending/failed` hacia estado resuelto.
+- Exactly one final consent exists in `consents`.
+- `offline_sync/{dedupeKey}` exists for that operation.
+- Retrying the same payload does not create a second consent.
+- The reserved sequence matches the final acknowledgment.
+- The queue item moves from `pending/failed` to a resolved state.
 
-## Datos a capturar
+## Data to capture
 
 - `dedupeKey`
-- timestamp local de firma (`signedAtLocal`)
-- ID del consentimiento final
-- consecutivo final
-- mensaje visible al operador
+- Local signing timestamp (`signedAtLocal`)
+- Final consent ID.
+- Final sequence.
+- Operator-visible message.
 
-## Fallas comunes
+## Common failures
 
-| Sintoma | Lectura tecnica | Accion |
+| Symptom | Technical reading | Action |
 | --- | --- | --- |
-| el item queda en `failed` | error de red o payload invalido | revisar `lastError`, reintentar con red estable |
-| aparecen dos consentimientos | fallo de idempotencia | desactivar `OFFLINE_QUEUE_ENABLED` y `NEXT_PUBLIC_OFFLINE_QUEUE_ENABLED`, luego abrir incidente |
-| no existe `offline_sync` | el replay no llego al ledger | revisar API `/api/consentimientos` y `consentService` |
+| the item stays in `failed` | network error or invalid payload | inspect `lastError`, then retry with stable connectivity |
+| two consents appear | idempotency failure | disable `OFFLINE_QUEUE_ENABLED` and `NEXT_PUBLIC_OFFLINE_QUEUE_ENABLED`, then open an incident |
+| `offline_sync` does not exist | the replay never reached the ledger | inspect `/api/consentimientos` and `consentService` |
 
-## Salida del drill
+## Drill output
 
-Registrar resultado como `PASS` o `FAIL` junto con:
+Record the result as `PASS` or `FAIL` together with:
 
-- ambiente
-- operador
+- environment
+- operator
 - dedupeKey
-- evidencia de `consents`
-- evidencia de `offline_sync`
+- `consents` evidence
+- `offline_sync` evidence

--- a/docs/runbooks/production-hardening.md
+++ b/docs/runbooks/production-hardening.md
@@ -1,23 +1,26 @@
 # Production hardening hub
 
-Este documento es la puerta de entrada operativa. Si vas a validar, habilitar o revertir una capacidad del roadmap, arrancas aca y despues seguis el runbook especializado.
+This document is the operational entry point. If you need to validate, enable, or roll back a roadmap capability, start here and then move to the specialized runbook.
 
-Companeros actuales de este hub:
+Current companions of this hub:
 
-- `docs/README.md` para distinguir docs vigentes vs historicas.
-- `docs/runbooks/dependency-risk-note.md` para el estado actual de `bun audit` y el riesgo residual aceptado (hoy: solo transitivo/tooling, no dependencias runtime directas reportadas).
+- `docs/README.md` to distinguish active docs from historical ones.
+- `docs/runbooks/dependency-risk-note.md` for the current `bun audit` status and the accepted residual risk (today: transitive/tooling only, no reported direct runtime dependencies).
+- `docs/runbooks/git-history-mp4-purge.md` for the procedure to scrub `.mp4` binaries from git history when they leak into a release branch.
+- `docs/runbooks/lighthouse-budget-rationale.md` for the rationale behind the current Lighthouse performance budget and the documented exceptions.
+- `docs/runbooks/otp-operational-policy.md` for the operational policy covering admin OTP issuance, rotation, and incident response.
 
-## Orden recomendado
+## Recommended order
 
-1. Confirmar flags y entorno con `docs/runbooks/rollback-flags.md`.
-2. Validar admin cost plane con `docs/runbooks/admin-cost-smoke-checklist.md`.
-3. Ejecutar drill offline con `docs/runbooks/offline-replay-drill.md` si `OFFLINE_QUEUE_ENABLED=true` y `NEXT_PUBLIC_OFFLINE_QUEUE_ENABLED=true`.
-4. Validar SEO/AI-SEO + notas a11y con `docs/runbooks/seo-ai-seo-validation-checklist.md` antes de abrir indexacion.
-5. Revisar `docs/runbooks/dependency-risk-note.md` antes de endurecer el gate de dependencias o aceptar upgrades grandes.
+1. Confirm flags and environment with `docs/runbooks/rollback-flags.md`.
+2. Validate the admin cost plane with `docs/runbooks/admin-cost-smoke-checklist.md`.
+3. Run the offline drill with `docs/runbooks/offline-replay-drill.md` if `OFFLINE_QUEUE_ENABLED=true` and `NEXT_PUBLIC_OFFLINE_QUEUE_ENABLED=true`.
+4. Validate SEO/AI-SEO and a11y notes with `docs/runbooks/seo-ai-seo-validation-checklist.md` before opening indexing.
+5. Review `docs/runbooks/dependency-risk-note.md` before tightening the dependency gate or accepting large upgrades.
 
 Firebase IaC parity: review `firebase/firestore.indexes.json`, `firebase/firestore.rules`, and `firebase/storage.rules` before any flag enablement.
 
-## Smoke pack minimo por release
+## Minimum release smoke pack
 
 - `bun test`
 - `bun test tests/phase4-production-artifacts.test.ts`
@@ -25,29 +28,29 @@ Firebase IaC parity: review `firebase/firestore.indexes.json`, `firebase/firesto
 - `bun run check:types`
 - `bun run check:phase5`
 
-## Nota importante sobre CI
+## Important CI note
 
-- `bun run check:format` y `bun run check:lint` ya no escriben archivos.
-- Si necesitás corregir localmente, usá `bun run fix:format` y `bun run fix:lint`.
-- No uses un gate que muta el workspace: eso rompe reproducibilidad y te ensucia la evidencia.
+- `bun run check:format` and `bun run check:lint` no longer write files.
+- If you need local fixes, use `bun run fix:format` and `bun run fix:lint`.
+- Do not use a gate that mutates the workspace: that breaks reproducibility and contaminates the evidence.
 
-## Criterio de aprobacion
+## Approval criteria
 
-No habilitar flags nuevos en produccion si falta alguno de estos puntos:
+Do not enable new flags in production if any of these points are missing:
 
-- rollback documentado y probado;
-- smoke de costo admin estable;
-- replay offline sin duplicados cuando aplica;
-- SEO/AI-SEO validado sobre el deploy real;
-- notas manuales de a11y registradas.
+- Documented and tested rollback.
+- Stable admin cost smoke.
+- Offline replay without duplicates when it applies.
+- SEO/AI-SEO validated against the real deployment.
+- Manual a11y notes recorded.
 
-## Limitaciones vigentes que NO hay que maquillar
+## Current limitations we must NOT hide
 
-- Dependencias: `bun audit` sigue mostrando riesgo residual transitivo/tooling. El gate actual bloquea hallazgos directos nuevos, pero no inventa que la deuda upstream ya desaparecio.
-- Accesibilidad: ya existe smoke browser reproducible con Axe/Playwright (`bun run test:a11y:e2e`), pero todavia no cubre una matriz E2E completa de todas las rutas admin/kiosk.
+- Dependencies: `bun audit` still shows residual transitive/tooling risk. The current gate blocks new direct findings, but it does not pretend the upstream debt has already disappeared.
+- Accessibility: a reproducible browser smoke already exists with Axe/Playwright (`bun run test:a11y:e2e`), but it still does not cover a full E2E matrix for every admin/kiosk route.
 
 ## CSP staged tightening
 
-- Baseline enforced: `src/proxy.ts` siempre emite un CSP activo con `frame-src 'none'`, `object-src 'none'`, `worker-src 'self' blob:`, `manifest-src 'self'` y sin origenes remotos amplios para scripts.
-- Canary opcional: `CSP_REPORT_ONLY_ENABLED=true` agrega un header `Content-Security-Policy-Report-Only` mas estricto para observar compatibilidad antes de endurecer enforcement.
-- Limitacion conocida: `unsafe-inline` sigue presente por compatibilidad con el runtime actual y el JSON-LD inline del surface publico; NO lo saques en produccion sin primero cubrir nonces/hashes y smoke browser real.
+- Baseline enforced: `src/proxy.ts` always emits an active CSP with `frame-src 'none'`, `object-src 'none'`, `worker-src 'self' blob:`, `manifest-src 'self'`, and no broad remote script origins.
+- Optional canary: `CSP_REPORT_ONLY_ENABLED=true` adds a stricter `Content-Security-Policy-Report-Only` header so compatibility can be observed before tightening enforcement.
+- Known limitation: `unsafe-inline` is still present for compatibility with the current runtime and the inline JSON-LD on the public surface; do NOT remove it in production until nonces/hashes and a real browser smoke are covered first.

--- a/docs/runbooks/rollback-flags.md
+++ b/docs/runbooks/rollback-flags.md
@@ -1,63 +1,63 @@
 # Rollback flags
 
-Este runbook define como revertir rapido las capacidades agregadas sin tocar datos productivos. Todos los cambios de este roadmap son additive-first: el rollback es por flag + redeploy.
+This runbook defines how to roll back the shipped capabilities quickly without touching production data. Every change in this roadmap is additive-first: the rollback path is flag + redeploy.
 
-## Matriz de rollback
+## Rollback matrix
 
-| Flag | Cuando desactivarlo | Efecto esperado | Riesgo residual |
+| Flag | When to disable it | Expected effect | Residual risk |
 | --- | --- | --- | --- |
-| `CURSOR_PAGINATION_ENABLED` | cursores invalidos, drift de paginacion, soporte incidente | vuelve a `offset` | mayor costo de lectura |
-| `ADMIN_AGGREGATES_ENABLED` | stale metrics o inconsistencia de agregados | vuelve a stats live | mas lecturas y mas latencia |
-| `OFFLINE_QUEUE_ENABLED` | cola corrupta, replay dudoso, incidente kiosk | desactiva replay backend | si el flag publico sigue activo queda un rollout parcial |
-| `NEXT_PUBLIC_OFFLINE_QUEUE_ENABLED` | UI offline inestable, storage local corrupto, incidente kiosk | desactiva queue UX/runtime en navegador | si el flag server sigue activo no se capturan nuevas colas |
-| `CSP_REPORT_ONLY_ENABLED` | ruido excesivo en reportes o incompatibilidad de terceros | elimina header report-only | menor visibilidad preventiva |
-| `PUBLIC_SEO_ENABLED` | noindex urgente, contenido publico no aprobado | `robots` bloquea todo y sitemap queda vacio | perdida temporal de discoverability |
+| `CURSOR_PAGINATION_ENABLED` | invalid cursors, pagination drift, cost-support incident | falls back to `offset` | higher read cost |
+| `ADMIN_AGGREGATES_ENABLED` | stale metrics or aggregate inconsistency | falls back to live stats | more reads and more latency |
+| `OFFLINE_QUEUE_ENABLED` | corrupted queue, replay doubt, kiosk incident | disables backend replay | if the public flag stays enabled, the rollout remains partial |
+| `NEXT_PUBLIC_OFFLINE_QUEUE_ENABLED` | unstable offline UI, corrupted local storage, kiosk incident | disables queue UX/runtime in the browser | if the server flag stays enabled, no new queues are captured |
+| `CSP_REPORT_ONLY_ENABLED` | excessive report noise or third-party incompatibility | removes the report-only header | lower preventive visibility |
+| `PUBLIC_SEO_ENABLED` | urgent noindex need, unapproved public content | `robots` blocks everything and the sitemap becomes empty | temporary discoverability loss |
 
-## Procedimiento
+## Procedure
 
-1. Confirmar el flag afectado y el sintoma.
-2. Cambiar la variable de entorno en el ambiente afectado.
-3. Redeploy obligatorio para preview/produccion.
-4. Validar el estado post-rollback con el runbook correspondiente.
-5. Registrar evidencia: hora, responsable, motivo, y ambiente.
+1. Confirm the affected flag and the symptom.
+2. Change the environment variable in the affected environment.
+3. Redeploy is mandatory for preview/production.
+4. Validate the post-rollback state with the corresponding runbook.
+5. Record evidence: time, owner, reason, and environment.
 
-Si hay drift de indices/reglas, redeploy de `firestore.indexes.json`, `firestore.rules` y `storage.rules` antes de reactivar flags.
+If index/rules drift exists, redeploy `firestore.indexes.json`, `firestore.rules`, and `storage.rules` before re-enabling flags.
 
-Nota: el rollout offline es dual. Normalmente se cambian `OFFLINE_QUEUE_ENABLED` y `NEXT_PUBLIC_OFFLINE_QUEUE_ENABLED` juntos para evitar estados mixtos.
+Note: the offline rollout is dual. Normally `OFFLINE_QUEUE_ENABLED` and `NEXT_PUBLIC_OFFLINE_QUEUE_ENABLED` are changed together to avoid mixed states.
 
-## Verificaciones por rollback
+## Rollback verification
 
 ### Cursor rollback
 
-- `GET /api/admin/users?offset=0&limit=20` responde correctamente.
-- `pageInfo.nextCursor` puede quedar `null`; eso es aceptable en fallback.
-- el incidente de costo queda contenido solo como medida temporal.
+- `GET /api/admin/users?offset=0&limit=20` responds correctly.
+- `pageInfo.nextCursor` may become `null`; that is acceptable in fallback mode.
+- The cost incident remains contained only as a temporary measure.
 
 ### Aggregates rollback
 
-- `/api/admin/stats` y `/api/admin/stats/detailed` responden desde live reads.
-- la UI sigue mostrando `freshness`, pero la fuente puede pasar a `live`.
+- `/api/admin/stats` and `/api/admin/stats/detailed` respond from live reads.
+- The UI still shows `freshness`, but the source may switch to `live`.
 
 ### Offline rollback
 
-- el kiosk deja de aceptar nuevas escrituras offline solo si tambien se desactiva `NEXT_PUBLIC_OFFLINE_QUEUE_ENABLED`.
-- las colas existentes no se borran automaticamente: conservar hasta decidir replay o limpieza manual.
+- The kiosk stops accepting new offline writes only if `NEXT_PUBLIC_OFFLINE_QUEUE_ENABLED` is also disabled.
+- Existing queues are not deleted automatically: keep them until replay or manual cleanup is decided.
 
 ### CSP rollback / canary rollback
 
-- `CSP_REPORT_ONLY_ENABLED=false` elimina solo el canary report-only; el baseline enforced sigue activo.
-- si el problema viene del baseline enforced, tratarlo como incidente de seguridad y corregir allowlists/directivas en `src/proxy.ts` antes del siguiente deploy.
+- `CSP_REPORT_ONLY_ENABLED=false` removes only the report-only canary; the enforced baseline remains active.
+- If the problem comes from the enforced baseline, treat it as a security incident and fix allowlists/directives in `src/proxy.ts` before the next deploy.
 
 ### SEO rollback
 
-- `robots.txt` muestra `Disallow: /`.
-- `sitemap.xml` no lista rutas publicas.
-- `/consentimiento-digital` vuelve a `noindex, nofollow`.
+- `robots.txt` shows `Disallow: /`.
+- `sitemap.xml` does not list public routes.
+- `/consentimiento-digital` falls back to `noindex, nofollow`.
 
-## Evidencia minima
+## Minimum evidence
 
-- ambiente afectado;
-- flag cambiado;
-- redeploy asociado;
-- smoke ejecutado;
-- decision de follow-up.
+- affected environment;
+- changed flag;
+- associated redeploy;
+- smoke executed;
+- follow-up decision.

--- a/docs/runbooks/rollback-flags.md
+++ b/docs/runbooks/rollback-flags.md
@@ -21,7 +21,7 @@ This runbook defines how to roll back the shipped capabilities quickly without t
 4. Validate the post-rollback state with the corresponding runbook.
 5. Record evidence: time, owner, reason, and environment.
 
-If index/rules drift exists, redeploy `firestore.indexes.json`, `firestore.rules`, and `storage.rules` before re-enabling flags.
+If index/rules drift exists, redeploy `firebase/firestore.indexes.json`, `firebase/firestore.rules`, and `firebase/storage.rules` before re-enabling flags.
 
 Note: the offline rollout is dual. Normally `OFFLINE_QUEUE_ENABLED` and `NEXT_PUBLIC_OFFLINE_QUEUE_ENABLED` are changed together to avoid mixed states.
 

--- a/docs/runbooks/seo-ai-seo-validation-checklist.md
+++ b/docs/runbooks/seo-ai-seo-validation-checklist.md
@@ -1,57 +1,57 @@
 # SEO and AI-SEO validation checklist
 
-Este checklist mezcla tres cosas que TIENEN que convivir: indexabilidad real, claridad para agentes, y una validacion manual minima de accesibilidad de la superficie publica.
+This checklist combines three things that MUST coexist: real indexability, agent clarity, and a minimum manual accessibility validation for the public surface.
 
 ## Preconditions
 
 - `PUBLIC_SEO_ENABLED=true`
-- deploy fresco del ambiente a validar
-- URL real del ambiente disponible
+- Fresh deployment of the environment to validate.
+- Real environment URL available.
 
 ## Search engine checks
 
-- `robots.txt` responde `200` y no expone admin ni rutas privadas del kiosk.
-- `sitemap.xml` lista solo URLs publicas canonicas.
-- `/consentimiento-digital` expone `title`, `description`, canonical y Open Graph coherentes.
-- la pagina publica incluye JSON-LD valido.
-- cuando el flag esta apagado, `robots.txt` vuelve a `Disallow: /` y la ruta publica queda `noindex`.
+- `robots.txt` responds with `200` and does not expose admin or private kiosk routes.
+- `sitemap.xml` lists canonical public URLs only.
+- `/consentimiento-digital` exposes coherent `title`, `description`, canonical, and Open Graph metadata.
+- The public page includes valid JSON-LD.
+- When the flag is disabled, `robots.txt` falls back to `Disallow: /` and the public route becomes `noindex`.
 
 ## AI-SEO checks
 
-- `/llms.txt` responde `text/plain`.
-- el archivo describe el producto, lista URLs publicas y deja claro que admin/kiosk/API son privados.
-- la URL canonica preferida coincide con la del sitemap.
-- la narrativa publica es corta, citable y sin claims inventados.
-- no se publican rutas privadas como si fueran surface marketing.
+- `/llms.txt` responds with `text/plain`.
+- The file describes the product, lists public URLs, and makes it clear that admin/kiosk/API surfaces are private.
+- The preferred canonical URL matches the sitemap.
+- The public narrative is short, citable, and free of invented claims.
+- Private routes are not published as if they were marketing surfaces.
 
 ## Public-page a11y smoke notes
 
-La superficie publica es chica, asi que la verificacion manual tambien debe ser precisa:
+The public surface is small, so the manual verification should be precise too:
 
-- navegar con teclado desde el inicio hasta el CTA principal;
-- verificar un solo `h1` y jerarquia logica de headings;
-- probar zoom/browser text resize al 200% sin clipping horizontal critico;
-- validar contraste visible en CTA y texto principal;
-- confirmar que enlaces tienen destino entendible fuera de contexto.
+- navigate with the keyboard from the entry point to the main CTA;
+- verify a single `h1` and a logical heading hierarchy;
+- test 200% zoom/browser text resize without critical horizontal clipping;
+- validate visible contrast on the CTA and main text;
+- confirm links have destinations that remain understandable out of context.
 
-## Cobertura automatizada disponible vs gap real
+## Available automated coverage vs real gap
 
-- Cobertura de regression de primitives: `tests/block-e-a11y-smoke.test.tsx` valida semantica modal, landmarks y el baseline de foco esperado para dialogos.
-- Cobertura browser reproducible en repo: `bun run test:a11y:e2e` (Playwright + Axe) sobre `/consentimiento-digital` y un surface kiosk critico.
-- Gap explicito actual: esta cobertura es smoke E2E, no reemplaza una matriz completa de navegacion asistiva para todo admin/kiosk.
-- Siguiente paso cuando entre en alcance: ampliar `playwright/accessibility.a11y.ts` con rutas admin clave y escenarios de foco/zoom extendidos.
+- Primitive-regression coverage: `tests/block-e-a11y-smoke.test.tsx` validates modal semantics, the main landmark, and the expected focus baseline for dialogs.
+- Reproducible browser coverage in the repo: `bun run test:a11y:e2e` (Playwright + Axe) over `/consentimiento-digital` and one critical kiosk surface.
+- Current explicit gap: this coverage is E2E smoke, not a replacement for a full assistive-navigation matrix across the entire admin/kiosk surface.
+- Next step when it enters scope: extend `playwright/accessibility.a11y.ts` with key admin routes and broader focus/zoom scenarios.
 
 ## Evidence pack
 
-- captura de `robots.txt`
-- captura de `sitemap.xml`
-- view-source o evidencia del JSON-LD
-- captura o nota de `llms.txt`
-- nota corta de a11y smoke: teclado + zoom + headings
+- capture of `robots.txt`
+- capture of `sitemap.xml`
+- view-source or other evidence of the JSON-LD
+- capture or note for `llms.txt`
+- short a11y smoke note: keyboard + zoom + headings
 
 ## Recommended external validators
 
 - Google Rich Results Test
 - Schema.org Validator
-- PageSpeed Insights o Lighthouse SEO
-- chequeo manual en al menos un agente con web access para confirmar que la URL canonica es facil de citar
+- PageSpeed Insights or Lighthouse SEO
+- manual check in at least one agent with web access to confirm the canonical URL is easy to cite

--- a/tests/phase4-production-artifacts.test.ts
+++ b/tests/phase4-production-artifacts.test.ts
@@ -246,7 +246,7 @@ describe('phase 4 docs and ci parity', () => {
 		expect(architecture).toContain('Exact composite-index parity is still a best-effort proof until emulator/query logs or deploy feedback confirm every live query shape.')
 
 		expect(productionHardening).toContain('Firebase IaC parity: review `firebase/firestore.indexes.json`, `firebase/firestore.rules`, and `firebase/storage.rules` before any flag enablement.')
-		expect(rollbackFlags).toContain('If index/rules drift exists, redeploy `firestore.indexes.json`, `firestore.rules`, and `storage.rules` before re-enabling flags.')
+		expect(rollbackFlags).toContain('If index/rules drift exists, redeploy `firebase/firestore.indexes.json`, `firebase/firestore.rules`, and `firebase/storage.rules` before re-enabling flags.')
 		expect(offlineReplayDrill).toContain('Do not run this drill in production with the default flags disabled; enable it in a controlled preview or staging environment first.')
 		expect(adminCostChecklist).toContain('If a query needs a new or different index, do not enable the flag yet: update the IaC first, then validate again against emulator/query logs.')
 	})

--- a/tests/phase4-production-artifacts.test.ts
+++ b/tests/phase4-production-artifacts.test.ts
@@ -246,9 +246,9 @@ describe('phase 4 docs and ci parity', () => {
 		expect(architecture).toContain('Exact composite-index parity is still a best-effort proof until emulator/query logs or deploy feedback confirm every live query shape.')
 
 		expect(productionHardening).toContain('Firebase IaC parity: review `firebase/firestore.indexes.json`, `firebase/firestore.rules`, and `firebase/storage.rules` before any flag enablement.')
-		expect(rollbackFlags).toContain('Si hay drift de indices/reglas, redeploy de `firestore.indexes.json`, `firestore.rules` y `storage.rules` antes de reactivar flags.')
-		expect(offlineReplayDrill).toContain('No correr este drill en produccion con los flags por defecto apagados; primero habilitarlo de forma controlada en preview o staging.')
-		expect(adminCostChecklist).toContain('Si algun query exige un indice nuevo o distinto, no habilitar el flag: primero actualizar IaC y volver a validar contra emulator/query logs.')
+		expect(rollbackFlags).toContain('If index/rules drift exists, redeploy `firestore.indexes.json`, `firestore.rules`, and `storage.rules` before re-enabling flags.')
+		expect(offlineReplayDrill).toContain('Do not run this drill in production with the default flags disabled; enable it in a controlled preview or staging environment first.')
+		expect(adminCostChecklist).toContain('If a query needs a new or different index, do not enable the flag yet: update the IaC first, then validate again against emulator/query logs.')
 	})
 
 	it('keeps CI focused on reproducible static gates and tests before build verification', () => {


### PR DESCRIPTION
## Summary

Ports 6 Spanish runbooks to English and updates the production hardening hub to satisfy spec requirement R14.

## Changes (367 lines)

### Runbooks Translated
- \docs/runbooks/production-hardening.md\: Hub — English port + 3 added links
- \docs/runbooks/offline-replay-drill.md\: Offline replay drill
- \docs/runbooks/admin-cost-smoke-checklist.md\: Admin cost validation
- \docs/runbooks/rollback-flags.md\: Feature flag rollback
- \docs/runbooks/dependency-risk-note.md\: Dependency audit status
- \docs/runbooks/seo-ai-seo-validation-checklist.md\: SEO + AI-SEO validation (fixed stale test reference)

### Hub Improvements
Added 3 missing links to \production-hardening.md\:
- \git-history-mp4-purge.md\
- \lighthouse-budget-rationale.md\
- \otp-operational-policy.md\

### Test Updates
- \	ests/phase4-production-artifacts.test.ts\: Updated 3 Spanish string assertions → English

### Extraction Sources
- \docs/.extraction-sources.md\: Added 6 entries with source commit \6e5a3de\

## Verification

- ✅ \un test\: 237 pass, 0 fail
- ✅ \un run check:types\: clean (2 pre-existing ImportMeta.dir errors)
- ✅ \un run check:docs\: 4/4 phases pass
- ✅ \un run check:format\: clean

## Spec Compliance

- **R14**: Runbooks discoverable from hub with per-topic drill-down ✅
- **R17**: Extraction from branch includes only pure docs, no test regression ✅
- **R18**: Source commit SHA recorded in extraction sources ✅
- **R20**: Internal cross-references resolve ✅
- **R22**: Mechanical docs check passes ✅
- **R24**: 367 lines (under 400-line budget) ✅

## Discoveries

- \check:docs:links\ validates backtick-delimited repo paths
- \	ests/phase4-production-artifacts.test.ts\ has cross-doc parity assertions that needed updating
- \	ests/block-b-a11y-and-logging.test.tsx\ does NOT exist on main; only \	ests/block-e-a11y-smoke.test.tsx\ does

Closes task 5.1 of \portfolio-product-documentation-overhaul\.