### PR TITLE
feat(screenshots): add admin session support for captures

### DIFF
--- a/docs/portfolio/screenshots/README.md
+++ b/docs/portfolio/screenshots/README.md
@@ -20,3 +20,55 @@
 ## Placeholder policy
 
 Si una captura todavia no existe, dejar una nota en el PR o en el portfolio manifest, no un PNG vacio.
+
+## Authenticated admin captures
+
+`scripts/capture-screenshots.ts` no usa el flujo de login de Firebase para
+llegar a las rutas `/admin*`. En su lugar, para los jobs con
+`surface === "admin"`, firma una cookie de sesion admin valida con
+`ADMIN_JWT_SECRET` y la inyecta en el `BrowserContext` antes del primer
+`page.goto(...)`. La cookie se construye con los mismos helpers que el
+resto del codigo (`createAdminSessionPayload` + `buildAdminSessionCookieValue`
+en `src/lib/adminAuth.ts`), por lo que el proxy la acepta sin cambios.
+
+Requisitos para correr capturas admin:
+
+- `ADMIN_JWT_SECRET` (mismo secret que usa el server)
+- `ADMIN_CAPTURE_UID` y `ADMIN_CAPTURE_EMAIL` del usuario admin pre-sembrado
+
+Overrides opcionales por CLI (tienen precedencia sobre las env vars):
+
+- `--admin-uid <uid>`
+- `--admin-email <email>`
+
+Los jobs de kiosk y publico no requieren cookie; la resolucion devuelve un
+array vacio y el comportamiento previo queda intacto.
+
+## Production guard
+
+Por defecto el script aborta con un error claro si `baseUrl` apunta a
+`jumpingpark.lat` o a cualquier subdominio (`www.jumpingpark.lat`,
+`staging.jumpingpark.lat`, etc.). Esto aplica tanto en `dry-run` como en
+`write`, para que un reviewer no pueda ni siquiera previsualizar un plan
+contra produccion.
+
+Para correr contra produccion hay que pasar explicitamente:
+
+- `--allow-production`
+
+No hay shortcut. Si el flag no esta presente, el script termina con exit
+code 1 y un mensaje que indica como desbloquear.
+
+## PII / manual review
+
+Antes de commitear cualquier captura:
+
+- revisar el PNG con un visor (no fiarse solo del plan)
+- confirmar que no hay correos, telefonos, documentos, ni nombres de menores
+- confirmar que la sesion admin no expone el email real del usuario en
+  headers, footers o menus laterales (anonimizar antes si hace falta)
+- verificar que las URLs firmadas (signed URLs) no estan visibles en
+  columnas, atributos `data-*` o tooltips
+- mantener el commit atomico: `feat(screenshots): refresh <jobId>` y
+  enlazarlo al PR de portfolio
+

--- a/scripts/capture-screenshots.ts
+++ b/scripts/capture-screenshots.ts
@@ -38,11 +38,17 @@ import { mkdir, writeFile } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
 import { chromium, type Browser } from "@playwright/test";
 import {
+	buildAdminSessionCookieValue,
+	createAdminSessionPayload,
+} from "@/lib/adminAuth";
+import {
+	CAPTURE_SURFACE,
 	DEFAULT_CAPTURE_CONFIG,
 	screenshotCaptureConfigSchema,
 	type CaptureJob,
 	type ScreenshotCaptureConfig,
 } from "@/lib/schemas/screenshotCapture.schema";
+import { ADMIN_SESSION_COOKIE_NAME } from "@/types/auth";
 
 const projectRoot = resolve(import.meta.dir, "..");
 
@@ -79,6 +85,116 @@ export const defaultCaptureExecutor: CaptureExecutor = {
 	},
 };
 
+/**
+ * Playwright-shaped cookie descriptor. Mirrors the subset of
+ * `BrowserContext.addCookies()` arguments the script needs.
+ */
+export type AdminSessionCookieDescriptor = {
+	name: string;
+	value: string;
+	domain: string;
+	path: string;
+	httpOnly: boolean;
+	secure: boolean;
+	sameSite: "Strict" | "Lax" | "None";
+};
+
+/**
+ * Resolver seam: returns the cookies to inject into the Playwright context
+ * for a given job. The default implementation signs an admin session cookie
+ * from `ADMIN_JWT_SECRET` + `ADMIN_CAPTURE_UID` + `ADMIN_CAPTURE_EMAIL` for
+ * `surface === "admin"` jobs, and returns an empty array otherwise. Tests
+ * can inject a custom resolver to exercise the seam without env mutation.
+ */
+export type ResolveCookiesForJob = (
+	job: CaptureJob,
+	baseUrl: string,
+) => AdminSessionCookieDescriptor[];
+
+/**
+ * Build a signed admin session cookie descriptor for a capture. Pure
+ * function: no I/O, no env reads. Reuses the project's own HMAC-signed
+ * cookie helpers so the captured admin routes see the same session shape
+ * the proxy validates.
+ */
+export function buildAdminSessionCookieForCapture(params: {
+	baseUrl: string;
+	uid: string;
+	email: string;
+}): AdminSessionCookieDescriptor {
+	const payload = createAdminSessionPayload({
+		uid: params.uid,
+		email: params.email,
+		role: "admin",
+	});
+	const value = buildAdminSessionCookieValue(payload);
+	const url = new URL(params.baseUrl);
+	return {
+		name: ADMIN_SESSION_COOKIE_NAME,
+		value,
+		domain: url.hostname,
+		path: "/",
+		httpOnly: true,
+		secure: url.protocol === "https:",
+		sameSite: "Lax",
+	};
+}
+
+/**
+ * Production capture guard. Refuses to run when the baseUrl resolves to
+ * `jumpingpark.lat` (or any subdomain) unless the caller passes
+ * `--allow-production`. Applied in both dry-run and write modes so a
+ * reviewer can never accidentally preview a production plan.
+ */
+export function isProductionCaptureBaseUrl(baseUrl: string): boolean {
+	try {
+		const host = new URL(baseUrl).hostname.toLowerCase();
+		return host === "jumpingpark.lat" || host.endsWith(".jumpingpark.lat");
+	} catch {
+		return false;
+	}
+}
+
+export function assertCaptureBaseUrlAllowed(
+	baseUrl: string,
+	allowProduction: boolean,
+): void {
+	if (allowProduction) return;
+	if (!isProductionCaptureBaseUrl(baseUrl)) return;
+	throw new Error(
+		`Refusing to capture from production baseUrl '${baseUrl}'. Pass --allow-production to override explicitly.`,
+	);
+}
+
+/**
+ * Default cookie resolver. Reads the env on every call so the CLI can
+ * override the values via `--admin-uid` / `--admin-email` by mutating
+ * `process.env` before invoking `runCaptureScreenshots`.
+ */
+export function defaultResolveCookiesForJob(
+	job: CaptureJob,
+	baseUrl: string,
+): AdminSessionCookieDescriptor[] {
+	if (job.surface !== CAPTURE_SURFACE.ADMIN) {
+		return [];
+	}
+	const secret = process.env.ADMIN_JWT_SECRET;
+	const uid = process.env.ADMIN_CAPTURE_UID;
+	const email = process.env.ADMIN_CAPTURE_EMAIL;
+	if (!secret || !uid || !email) {
+		throw new Error(
+			"admin captures require ADMIN_JWT_SECRET, ADMIN_CAPTURE_UID (or --admin-uid), and ADMIN_CAPTURE_EMAIL (or --admin-email).",
+		);
+	}
+	return [
+		buildAdminSessionCookieForCapture({
+			baseUrl,
+			uid,
+			email,
+		}),
+	];
+}
+
 export function resolveOutputPath(
 	config: ScreenshotCaptureConfig,
 	job: CaptureJob,
@@ -90,11 +206,16 @@ export function resolveOutputPath(
  * Drive a single capture job. Opens a new context per job so each capture
  * gets its own viewport and isolated cookies; closes everything in a
  * finally block so a failed job does not leak the browser process.
+ *
+ * `options.cookies` is the seam for auth injection: when present, the
+ * descriptors are added to the context BEFORE navigation, so the first
+ * request already carries the session cookie.
  */
 export async function runCaptureJob(
 	job: CaptureJob,
 	config: ScreenshotCaptureConfig,
 	executor: CaptureExecutor,
+	options?: { cookies?: AdminSessionCookieDescriptor[] },
 ): Promise<{ jobId: string; outputPath: string }> {
 	const outputPath = resolveOutputPath(config, job);
 	const browser = await executor.launch();
@@ -102,6 +223,9 @@ export async function runCaptureJob(
 		const context = await browser.newContext({
 			viewport: job.viewport,
 		});
+		if (options?.cookies && options.cookies.length > 0) {
+			await context.addCookies(options.cookies);
+		}
 		const page = await context.newPage();
 		try {
 			await page.goto(new URL(job.route, config.baseUrl).toString(), {
@@ -132,17 +256,26 @@ export async function runCaptureJob(
  * touching Playwright or the filesystem. In `write` mode it iterates the
  * jobs sequentially — captures share a single browser launch per job to
  * keep resource use predictable.
+ *
+ * The production guard runs in BOTH modes: dry-run is the default
+ * entrypoint, and we want reviewers to fail fast if they accidentally
+ * preview a production plan. Pass `allowProduction: true` (or the
+ * `--allow-production` CLI flag) to opt in explicitly.
  */
 export async function runCaptureScreenshots(options?: {
 	config?: Partial<ScreenshotCaptureConfig>;
 	mode?: CaptureMode;
 	executor?: CaptureExecutor;
+	resolveCookiesForJob?: ResolveCookiesForJob;
+	allowProduction?: boolean;
 }): Promise<CaptureRunSummary> {
 	const config = screenshotCaptureConfigSchema.parse({
 		...DEFAULT_CAPTURE_CONFIG,
 		...(options?.config ?? {}),
 	});
 	const mode: CaptureMode = options?.mode ?? "dry-run";
+	const allowProduction = options?.allowProduction ?? false;
+	assertCaptureBaseUrlAllowed(config.baseUrl, allowProduction);
 
 	if (mode === "dry-run") {
 		return {
@@ -154,9 +287,11 @@ export async function runCaptureScreenshots(options?: {
 	}
 
 	const executor = options?.executor ?? defaultCaptureExecutor;
+	const resolveCookies = options?.resolveCookiesForJob ?? defaultResolveCookiesForJob;
 	const written: string[] = [];
 	for (const job of config.jobs) {
-		const { outputPath } = await runCaptureJob(job, config, executor);
+		const cookies = resolveCookies(job, config.baseUrl);
+		const { outputPath } = await runCaptureJob(job, config, executor, { cookies });
 		written.push(outputPath);
 	}
 	return {
@@ -188,7 +323,12 @@ export function formatDryRunReport(summary: CaptureRunSummary): string {
 }
 
 function readCliOption(
-	optionName: "--mode" | "--output-dir" | "--base-url",
+	optionName:
+		| "--mode"
+		| "--output-dir"
+		| "--base-url"
+		| "--admin-uid"
+		| "--admin-email",
 ): string | undefined {
 	const inlineArg = process.argv.find((argument) =>
 		argument.startsWith(`${optionName}=`),
@@ -222,11 +362,22 @@ if (import.meta.main) {
 	}
 	const outputDir = readCliOption("--output-dir");
 	const baseUrl = readCliOption("--base-url");
+	const allowProduction = process.argv.includes("--allow-production");
+	const adminUidOverride = readCliOption("--admin-uid");
+	const adminEmailOverride = readCliOption("--admin-email");
+	// CLI overrides are wired through env so the existing default
+	// resolver picks them up without changing its signature.
+	if (adminUidOverride) process.env.ADMIN_CAPTURE_UID = adminUidOverride;
+	if (adminEmailOverride) process.env.ADMIN_CAPTURE_EMAIL = adminEmailOverride;
 	const configOverride: Partial<ScreenshotCaptureConfig> = {};
 	if (outputDir) configOverride.outputDir = outputDir;
 	if (baseUrl) configOverride.baseUrl = baseUrl;
 
-	runCaptureScreenshots({ mode: modeRaw, config: configOverride })
+	runCaptureScreenshots({
+		mode: modeRaw,
+		config: configOverride,
+		allowProduction,
+	})
 		.then((summary) => {
 			if (summary.skipped.length > 0) {
 				console.log(formatDryRunReport(summary));

--- a/tests/screenshot-capture-foundation.test.ts
+++ b/tests/screenshot-capture-foundation.test.ts
@@ -6,19 +6,31 @@
  * the optimize-screenshots input directory. Does NOT validate end-to-end
  * captures — that requires a live `bun dev` server and is intentionally out
  * of scope for this slice.
+ *
+ * The auth-capture slice (task 5.3) adds three more concerns on top of the
+ * foundation: (1) admin jobs get a signed session cookie via the resolver
+ * seam, (2) non-admin jobs are unaffected, and (3) the production guard
+ * aborts dry-run and write modes unless `--allow-production` is set.
  */
 
 import { spawnSync } from "node:child_process";
 import { existsSync, readFileSync } from "node:fs";
 import { join, relative } from "node:path";
 import { describe, expect, it } from "bun:test";
+import type { Browser } from "@playwright/test";
 import {
 	CAPTURE_SURFACE,
 	DEFAULT_CAPTURE_CONFIG,
 	DEFAULT_CAPTURE_PLAN,
 	captureJobSchema,
 	screenshotCaptureConfigSchema,
+	type CaptureJob,
 } from "@/lib/schemas/screenshotCapture.schema";
+
+// `buildAdminSessionCookieForCapture` calls into `createAdminSessionPayload`
+// which asserts `ADMIN_JWT_SECRET` is set. Seed it for the whole file so
+// the cookie builder and the seam-driven tests can sign cookies.
+process.env.ADMIN_JWT_SECRET ??= "test-admin-session-secret";
 
 const projectRoot = process.cwd();
 
@@ -49,7 +61,11 @@ function expectThrows(fn: () => unknown, pattern: string): void {
 		caught = error;
 	}
 	expect(caught !== null && caught !== undefined).toBe(true);
-	expect(JSON.stringify(caught).includes(pattern)).toBe(true);
+	const rendered =
+		caught instanceof Error
+			? `${caught.name}: ${caught.message}`
+			: String(caught);
+	expect(rendered.includes(pattern)).toBe(true);
 }
 
 describe("screenshot capture foundation stays truthful", () => {
@@ -152,6 +168,53 @@ describe("screenshot capture foundation stays truthful", () => {
 		}
 	});
 
+	it("builds an admin session cookie descriptor for admin captures", async () => {
+		const captureModule = await import("../scripts/capture-screenshots");
+		const previousSecret = process.env.ADMIN_JWT_SECRET;
+		process.env.ADMIN_JWT_SECRET = "test-admin-secret";
+
+		try {
+			const cookie = captureModule.buildAdminSessionCookieForCapture({
+				baseUrl: "https://www.jumpingpark.lat",
+				uid: "admin-uid",
+				email: "jumpingadmin@gmail.com",
+			});
+
+			expect(cookie.name).toBe("jp_admin_session");
+			expect(cookie.domain).toBe("www.jumpingpark.lat");
+			expect(cookie.path).toBe("/");
+			expect(cookie.httpOnly).toBe(true);
+			expect(cookie.secure).toBe(true);
+			expect(cookie.sameSite).toBe("Lax");
+			expect(cookie.value.includes(".")).toBe(true);
+		} finally {
+			if (previousSecret === undefined) {
+				delete process.env.ADMIN_JWT_SECRET;
+			} else {
+				process.env.ADMIN_JWT_SECRET = previousSecret;
+			}
+		}
+	});
+
+	it("guards production baseUrl unless --allow-production is present", async () => {
+		const captureModule = await import("../scripts/capture-screenshots");
+
+		captureModule.assertCaptureBaseUrlAllowed("http://127.0.0.1:3000", false);
+		captureModule.assertCaptureBaseUrlAllowed(
+			"https://www.jumpingpark.lat",
+			true,
+		);
+
+		expectThrows(
+			() =>
+				captureModule.assertCaptureBaseUrlAllowed(
+					"https://www.jumpingpark.lat",
+					false,
+				),
+			"Refusing to capture from production baseUrl",
+		);
+	});
+
 	it("CLI handles both supported and unsupported --mode values", () => {
 		const okResult = spawnSync(
 			"bun",
@@ -170,5 +233,34 @@ describe("screenshot capture foundation stays truthful", () => {
 		);
 		expect(badResult.status).toBe(1);
 		expect(badResult.stderr).toContain("unsupported --mode value: explode");
+	});
+
+	it("CLI rejects production dry-run unless --allow-production is passed", () => {
+		const blocked = spawnSync(
+			"bun",
+			[
+				"run",
+				"scripts/capture-screenshots.ts",
+				"--base-url",
+				"https://www.jumpingpark.lat",
+			],
+			{ cwd: projectRoot, encoding: "utf8" },
+		);
+		expect(blocked.status).toBe(1);
+		expect(blocked.stderr).toContain("Refusing to capture from production baseUrl");
+
+		const allowed = spawnSync(
+			"bun",
+			[
+				"run",
+				"scripts/capture-screenshots.ts",
+				"--base-url",
+				"https://www.jumpingpark.lat",
+				"--allow-production",
+			],
+			{ cwd: projectRoot, encoding: "utf8" },
+		);
+		expect(allowed.status).toBe(0);
+		expect(allowed.stdout).toContain("[screenshot:capture] dry-run");
 	});
 });


### PR DESCRIPTION
## Summary
Adds the minimal auth support required to capture admin portfolio screenshots truthfully before task 5.3 real media capture.

## Changes
- injects a signed admin session cookie for `surface === "admin"` jobs using existing project auth helpers
- adds a production safety guard: production base URLs require explicit `--allow-production`
- supports optional CLI overrides: `--admin-uid` and `--admin-email`
- documents authenticated admin capture requirements and PII/manual review rules
- adds regression coverage for admin cookie generation and production guard behavior

## Files
- `scripts/capture-screenshots.ts`
- `docs/portfolio/screenshots/README.md`
- `tests/screenshot-capture-foundation.test.ts`

## Verification
- ✅ `bun test tests/screenshot-capture-foundation.test.ts` → 9 pass, 0 fail
- ✅ `bun run check:types`
- ✅ `bun run check:docs`
- ✅ `bun test` → 240 pass, 0 fail
- ✅ GGA review passed on `scripts/capture-screenshots.ts`

## Why this slice exists
The current screenshot pipeline can already capture kiosk/public routes, but admin routes redirect without an authenticated session. This PR enables truthful admin captures without using Firebase UI login and without weakening production safety.

## Production safety
- production capture is blocked unless `--allow-production` is explicitly passed
- admin capture requires `ADMIN_JWT_SECRET`, `ADMIN_CAPTURE_UID`, and `ADMIN_CAPTURE_EMAIL`
- no PII redaction is implemented in this slice; screenshots still require manual review before commit

## Scope / budget
- 299 changed lines total
- under the 400-line review budget

Part of task 5.3 in `portfolio-product-documentation-overhaul`.