### PR TITLE
docs(portfolio): add evidence folder scaffold

### DIFF
--- a/docs/portfolio/README.md
+++ b/docs/portfolio/README.md
@@ -10,6 +10,7 @@ Hoy este directorio sigue siendo principalmente un **plan curado de captura**. P
 - `docs/portfolio/diagrams/` - guia para convertir los diagramas tecnicos actuales en assets curados de storytelling.
 - `docs/portfolio/motion/` - guion de GIF/video corto y checklist de toma.
 - `docs/portfolio/branding/` - recomendaciones de logo, naming y consistencia visual.
+- `docs/portfolio/evidence/` - plantillas de evidencia externa (Lighthouse, Rich Results, AI citation log, Search Console). Vacias hasta tener un run real; no se inventan resultados.
 
 ## Alcance de esta carpeta
 

--- a/docs/portfolio/evidence/README.md
+++ b/docs/portfolio/evidence/README.md
@@ -1,0 +1,43 @@
+# Portfolio evidence folder
+
+This folder holds **real, reviewable evidence** for the public marketing surface and the supporting public/private architecture. Every file here is a **placeholder template** until a real run produces actual numbers, and every value that lands here must come from a real validator, a real screenshot, or a real audit log — never from a guess.
+
+## Purpose
+
+- Capture outputs from external validators (Lighthouse, Rich Results Test, Search Console, AI agents) that are too expensive or too volatile to re-run on demand.
+- Make portfolio claims defensible: anyone reviewing the case study can trace a screenshot, score, or citation back to a specific run, a specific URL, and a specific date.
+- Keep an audit trail of public-surface SEO and AI-visibility work without leaking PII, real users, or unverifiable claims.
+
+## Anti-patterns (do NOT do this)
+
+- **Do not invent scores.** A green checkmark, a "100/100", or a fake screenshot is a worse signal than no evidence at all.
+- **Do not paste binary blobs you have not reviewed.** Every PNG, PDF, or HTML capture must be opened, scanned for PII, and confirmed truthful before commit. See `docs/portfolio/screenshots/README.md` for the PII/redaction checklist.
+- **Do not commit Lighthouse CI artifacts as evidence.** The `lighthouserc.json` upload target is `temporary-public-storage` — those artifacts expire. The committed evidence must come from a manual run with a saved screenshot or copy/paste of the report.
+- **Do not paraphrase a validator into a claim that the validator did not make.** If Schema.org flags a warning, the warning stays in the evidence — even if the page still validates.
+- **Do not copy production data into evidence.** Use demo data, redacted real data, or screenshots that have been through the PII checklist.
+
+## Authoritative references
+
+- `docs/runbooks/seo-ai-seo-validation-checklist.md` — the validation checklist that defines which external validators we run and what counts as a real pass.
+- `docs/ai-visibility-monthly-checklist.md` — the monthly cadence for AI-citation checks; the log below mirrors that table shape so the two stay aligned.
+
+## Files in this folder
+
+| File | What it captures | Status |
+| --- | --- | --- |
+| `lighthouse-seo-report-placeholder.md` | Real Lighthouse (or PageSpeed Insights) run for the canonical public URL — score, LCP, TBT, CLS, and notes. | Empty template |
+| `rich-results-placeholder.md` | Rich Results Test / Schema.org validator output for the public JSON-LD. | Empty template |
+| `ai-citation-log-placeholder.md` | Monthly AI citation check (Google AI Overviews, ChatGPT, Perplexity) — one row per query. | Empty template |
+| `search-console-placeholder.md` | Google Search Console evidence that requires external account access (impressions, clicks, indexing). | Empty template |
+
+## How to fill in a placeholder
+
+1. Run the validator or check the real source. Do not fabricate.
+2. Capture a screenshot or copy the raw report into the same commit. If the report is binary (HTML/JSON), store the raw file under a dated filename in this folder and link to it from the placeholder.
+3. Fill in the placeholder table with **only** what the validator actually returned. Leave a cell blank rather than guess.
+4. Add the run date, the URL tested, and any caveats in the `Notes` column.
+5. If a row contradicts a public claim in `README.md` or a runbook, treat that as a follow-up issue, not as something to quietly overwrite.
+
+## When a placeholder is still empty
+
+Empty placeholders are intentional. They mark the **next honest thing to do** for portfolio readiness and prevent the folder from drifting into fake evidence. If a reviewer sees an empty table, the message is: "this run has not happened yet, do not treat the project as having this evidence."

--- a/docs/portfolio/evidence/ai-citation-log-placeholder.md
+++ b/docs/portfolio/evidence/ai-citation-log-placeholder.md
@@ -1,0 +1,38 @@
+# AI citation log evidence
+
+This file is the **template** for the monthly AI citation check on the public marketing surface. It mirrors the table shape in `docs/ai-visibility-monthly-checklist.md` so the two stay aligned. It stays empty until a real monthly run is logged. Do not invent citations.
+
+## What real evidence looks like
+
+- One row per **query** (not per run). A month with five target queries produces five rows, one per platform.
+- The **actual platform** that was tested (Google AI Overviews, ChatGPT, Perplexity) and the **URL the platform cited**, if any.
+- A **screenshot or quoted snippet** of the model's answer, attached to the same commit. This is what makes the row auditable later.
+- The **month** the check was run, in `YYYY-MM` form, to keep this log roll-up-friendly with the runbook.
+
+## What does NOT count as evidence
+
+- A "Jumping Park is now cited everywhere" summary without per-query rows.
+- A cited URL that was not actually shown by the platform in that run. If a citation is in a "related links" sidebar, the row still says no citation for the **answer body** — be precise.
+- A row from a query that is not in the runbook's recommended mix. If a new query is added, the runbook should be updated first; the evidence follows.
+
+## Report template
+
+| Month | Query | Platform | Cited? | Cited URL | Competitor or third-party cited | Notes / follow-up |
+| --- | --- | --- | --- | --- | --- | --- |
+| YYYY-MM |  | Google AI Overviews | Yes / No |  |  |  |
+| YYYY-MM |  | ChatGPT | Yes / No |  |  |  |
+| YYYY-MM |  | Perplexity | Yes / No |  |  |  |
+
+## How to fill a row
+
+1. Pick the query from the runbook's recommended mix, or add it to the runbook first if the query is new.
+2. Run the query on the target platform with a clean session.
+3. Record whether the **answer body** cites Jumping Park. Treat a sidebar or "related links" only as a separate observation, not as a body citation.
+4. If cited, record the **exact URL** the platform surfaced. If a competitor or third party is cited instead, record that URL too.
+5. In `Notes`, capture: any drift from `/llms.txt` or `/pricing.md`, the public page that should be improved, and the issue link if a follow-up was opened.
+6. Attach the screenshot or quoted snippet to the same commit under a dated filename.
+
+## Cross-references
+
+- `docs/ai-visibility-monthly-checklist.md` — the runbook, the recommended query mix, and the escalation rule.
+- `docs/runbooks/seo-ai-seo-validation-checklist.md` — the AI-SEO checks this log rolls up into.

--- a/docs/portfolio/evidence/lighthouse-seo-report-placeholder.md
+++ b/docs/portfolio/evidence/lighthouse-seo-report-placeholder.md
@@ -1,0 +1,36 @@
+# Lighthouse SEO report evidence
+
+This file is the **template** for committed Lighthouse (or PageSpeed Insights) evidence for the public marketing surface. It stays empty until a real run is captured. Do not invent scores.
+
+## What real evidence looks like
+
+- A **manual run** of Lighthouse (Chrome DevTools) or PageSpeed Insights against the canonical public URL listed in the runbook `docs/runbooks/seo-ai-seo-validation-checklist.md`.
+- A **screenshot** of the Lighthouse summary panel (Performance, Accessibility, Best Practices, SEO categories) or a copy/paste of the JSON report.
+- The **build/deploy commit SHA** that was live when the run was taken, so the result can be reproduced.
+
+## What does NOT count as evidence
+
+- Lighthouse CI artifacts. `lighthouserc.json` uploads to `temporary-public-storage`, which **expires**. Treat CI as a guardrail, not as a portfolio record. See `docs/runbooks/lighthouse-budget-rationale.md` for the CI-vs-production rationale.
+- A redacted or paraphrased score. If the panel said "0.82", the table says "0.82" — not "good", not "passing", not "✅".
+- A number from a different URL or environment than the one declared in the table.
+
+## Report template
+
+| Date | URL tested | Environment | Performance | LCP (ms) | TBT (ms) | CLS | SEO | Notes |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| YYYY-MM-DD | https://www.example.com/consentimiento-digital | production |  |  |  |  |  |  |
+| YYYY-MM-DD | https://www.example.com/consentimiento-digital | preview |  |  |  |  |  |  |
+
+## How to fill a row
+
+1. Run Lighthouse or PageSpeed Insights against the URL with the same `PUBLIC_SEO_ENABLED` flag the production environment uses.
+2. Record the **four category scores** (Performance, Accessibility, Best Practices, SEO) as decimal numbers exactly as reported — do not round, do not invert.
+3. Record LCP, TBT, and CLS in the units shown by the report (ms and unitless).
+4. In `Notes`, capture: deploy commit SHA, any deviation from the budget, and any warnings Lighthouse surfaced.
+5. Attach the screenshot or raw JSON to the same commit, under a dated filename (for example `2026-06-15-lighthouse-production.json`).
+
+## Cross-references
+
+- `docs/runbooks/seo-ai-seo-validation-checklist.md` — when to run Lighthouse and what to look for.
+- `docs/runbooks/lighthouse-budget-rationale.md` — why CI numbers are looser than production, and what production should aim for.
+- `lighthouserc.json` — CI thresholds only; do not paste CI JSON here.

--- a/docs/portfolio/evidence/rich-results-placeholder.md
+++ b/docs/portfolio/evidence/rich-results-placeholder.md
@@ -1,0 +1,36 @@
+# Rich Results / Schema.org validator evidence
+
+This file is the **template** for evidence from Google's Rich Results Test and the Schema.org Validator against the public JSON-LD. It stays empty until a real validation run is captured. Do not paste a "passing" badge that was not produced by the validator.
+
+## What real evidence looks like
+
+- The **public URL** of the page that was tested (canonical, not a preview or staging URL).
+- The **raw output** from the Rich Results Test (detected structured data items, any warnings, any errors) and from the Schema.org Validator.
+- A **screenshot or copy/paste** of the validator result panel, attached to the same commit.
+- The **deploy commit SHA** that was live at the time of the run, so the result is reproducible.
+
+## What does NOT count as evidence
+
+- A "no errors detected" claim without the underlying report. Schema.org and Rich Results can both show partial coverage with hidden warnings.
+- A run against a non-canonical URL (preview, staging, dev). Public discoverability is judged on the canonical URL only.
+- Re-running a stale local copy of the JSON-LD. Always re-validate the live page after a deploy.
+
+## Report template
+
+| Date | URL tested | Validator | Detected types | Warnings | Errors | Notes |
+| --- | --- | --- | --- | --- | --- | --- |
+| YYYY-MM-DD | https://www.example.com/consentimiento-digital | Rich Results Test |  |  |  |  |
+| YYYY-MM-DD | https://www.example.com/consentimiento-digital | Schema.org Validator |  |  |  |  |
+
+## How to fill a row
+
+1. Open the validator with the canonical public URL.
+2. Record **every detected type** the validator surfaces (for example `LocalBusiness`, `BreadcrumbList`, `Organization`). Do not summarise — list them so a reviewer can confirm coverage.
+3. Record warnings and errors **as written by the validator**, even if the page still validates overall. A warning is a signal, not a decoration.
+4. In `Notes`, capture: deploy commit SHA, whether the run matched the public narrative, and any follow-up needed.
+5. Attach the raw validator output (HTML or JSON) to the same commit under a dated filename.
+
+## Cross-references
+
+- `docs/runbooks/seo-ai-seo-validation-checklist.md` — what the project commits to validating on the public surface.
+- `docs/portfolio/evidence/README.md` — anti-patterns for committed evidence (no invented pass/fail).

--- a/docs/portfolio/evidence/search-console-placeholder.md
+++ b/docs/portfolio/evidence/search-console-placeholder.md
@@ -1,0 +1,36 @@
+# Search Console evidence
+
+This file is the **template** for Google Search Console evidence that requires external account access. It stays empty until a real Search Console export is captured. Do not invent impressions, clicks, or indexing state.
+
+## What real evidence looks like
+
+- A **date range** that matches a real Search Console query (default is the last 28 days, or the current month).
+- The **URL or property** the export came from, so the row can be matched to the canonical public surface.
+- The **raw numbers** as Search Console reports them — impressions, clicks, average position, and indexing status. Do not invert or round.
+- A **screenshot of the Search Console panel** or a CSV/Excel export, attached to the same commit. The export is what makes the row auditable later.
+
+## What does NOT count as evidence
+
+- A summary like "everything is indexed" without the underlying report. Indexing exceptions are the most important signal in Search Console; they are easy to miss and easy to fake.
+- Numbers copied from a third-party SEO tool. The project commits to **Search Console as the source of truth** for indexing and click data.
+- A row from a property that is not the canonical public property (for example a staging or dev property).
+
+## Report template
+
+| Date range | Property | Impressions | Clicks | Avg. position | Indexed pages | Excluded pages | Notes |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| YYYY-MM-DD to YYYY-MM-DD | https://www.example.com/ |  |  |  |  |  |  |
+
+## How to fill a row
+
+1. Open Search Console for the canonical public property.
+2. Run the Performance report for the chosen date range. Use the default **Web** search type unless the runbook says otherwise.
+3. Run the **Pages > Indexing** report and record both indexed and excluded counts. Excluded pages are not a failure by themselves — note any unexpected exclusions in the `Notes` column.
+4. Record the raw totals as Search Console reports them. Do not normalise to per-day averages.
+5. In `Notes`, capture: any manual actions, any crawl anomalies, the deploy commit SHA the report window covers, and any follow-up issue opened.
+6. Attach the screenshot or CSV export to the same commit under a dated filename.
+
+## Cross-references
+
+- `docs/runbooks/seo-ai-seo-validation-checklist.md` — the indexability checks this evidence rolls up into.
+- `docs/portfolio/evidence/README.md` — anti-patterns for committed evidence (no fake green checks).


### PR DESCRIPTION
## Summary
Adds the initial docs/portfolio/evidence/ scaffold for external validation evidence without inventing any results.

## What this PR includes
- docs/portfolio/evidence/README.md
- docs/portfolio/evidence/lighthouse-seo-report-placeholder.md
- docs/portfolio/evidence/rich-results-placeholder.md
- docs/portfolio/evidence/ai-citation-log-placeholder.md
- docs/portfolio/evidence/search-console-placeholder.md
- one structure-line update in docs/portfolio/README.md

## Why this exists
The portfolio tree already has real screenshots, runbooks, and tests, but it lacked a committed place to store manual evidence from external tools such as Lighthouse, Rich Results, AI citation checks, and Search Console.

This PR creates the smallest truthful scaffold:
- no fake screenshots
- no fake green checks
- no invented scores
- only placeholders and instructions for the next honest validation pass

## Verification
- ✅ bun run check:docs → all 4 phases pass

## Scope / budget
- docs-only slice
- ~190 lines total
- well under the 400-line review budget

## Follow-up
Actual evidence collection still needs:
- a real Lighthouse / PSI run
- Rich Results / Schema validator results
- AI citation check entries
- Search Console data from an account with access

Part of Phase 6.1 in portfolio-product-documentation-overhaul.