### PR TITLE
docs(reference): tighten truthfulness and traceability

### DIFF
--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -3,7 +3,7 @@
 > **Status**: current
 > **Audit date**: 2026-05-24
 > **Diátaxis**: Reference
-> **Linked sources**: `src/app/api/*/route.ts` (32 route handlers), `src/services/` (13 service files), `src/lib/schemas/` (6 schema files)
+> **Linked sources**: `src/app/api/*/route.ts` (32 route handlers), `src/services/` (13 service files), `src/lib/schemas/` (7 schema/helper files)
 
 Manual source map of the Jumping Park API surface. Use this reference to find the shortest truthful path from a route handler to its service, validation contract, or schema helper.
 
@@ -12,7 +12,7 @@ Manual source map of the Jumping Park API surface. Use this reference to find th
 1. Start in **Route surface** (§3) to find the public, kiosk, or admin endpoint.
 2. Jump to **Service layer** (§2) to see which file owns the behavior.
 3. Check **Validation surface** (§4) when the request body or stored content is shaped by Zod.
-4. For local development verification, run `bun test` (the project's Bun test runner with 158+ test assertions).
+4. For local development verification, run `bun test` (the project's Bun test runner, with [UNVERIFIED] ~158+ test assertions — exact count drifts as suites are added/removed, so re-run `bun test` for a current number).
 
 ## 2. Service layer
 

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -102,7 +102,7 @@ Implementation: [`src/lib/adminCursor.ts`](../../src/lib/adminCursor.ts), [`src/
 Impact:
 
 - Reads bounded to 20–50 records per page.
-- More stable latency.
+- [UNVERIFIED] More stable latency (anecdotal — no controlled benchmark in this slice).
 - Immediate rollback via flag if operational drift appears.
 
 ## 6. Aggregates and recompute
@@ -163,16 +163,16 @@ Operational runbook: [`docs/runbooks/seo-ai-seo-validation-checklist.md`](../run
 
 ## 9. Security and rollout
 
-Current flags in [`src/lib/hardeningPolicy.ts`](../../src/lib/hardeningPolicy.ts):
+Current flags in [`src/lib/hardeningPolicy.ts`](../../src/lib/hardeningPolicy.ts) (flag constants at lines 1-9, env-key mapping at lines 11-19, default-enabled map at lines 21-29):
 
-- `OTP_HARDENING_ENABLED`
-- `EXPORT_BOUNDS_ENFORCED`
-- `PUBLIC_SEO_ENABLED`
-- `CURSOR_PAGINATION_ENABLED`
-- `ADMIN_AGGREGATES_ENABLED`
-- `OFFLINE_QUEUE_ENABLED`
-- `NEXT_PUBLIC_OFFLINE_QUEUE_ENABLED`
-- `CSP_REPORT_ONLY_ENABLED`
+- `OTP_HARDENING_ENABLED` (line 12)
+- `EXPORT_BOUNDS_ENFORCED` (line 13)
+- `PUBLIC_SEO_ENABLED` (line 14)
+- `CURSOR_PAGINATION_ENABLED` (line 15)
+- `ADMIN_AGGREGATES_ENABLED` (line 16)
+- `OFFLINE_QUEUE_ENABLED` (line 17)
+- `NEXT_PUBLIC_OFFLINE_QUEUE_ENABLED` (line 18; client-readable override path)
+- `CSP_REPORT_ONLY_ENABLED` (line 19)
 
 Principles:
 

--- a/docs/reference/firebase.md
+++ b/docs/reference/firebase.md
@@ -179,7 +179,7 @@ The auth system combines Firebase Custom Claims (admin/trabajador) with email-ba
 
 ### 5.1 Admin Authentication
 
-Admin/trabajador users authenticate through Firebase Auth with Custom Claims (role in JWT token). Implementation: `src/lib/adminAuth.ts`.
+Admin/trabajador users authenticate through Firebase Auth with Custom Claims (role in JWT token). Implementation: `src/lib/adminAuth.ts` (session mode + idle timeout at lines 15-22; `verifyAdminToken` at lines 282-298; `verifyFullAdminToken` at lines 300-304; `verifyAdminTokenWithPermission` at lines 306-323). Role definitions and the `ROUTE_ACCESS` map live in `src/types/auth.ts` (roles at line 27, `ROUTE_ACCESS` at lines 173-180).
 
 - **Session mode**: `ADMIN_SESSION_MODE` env var — `cookie` or `dual` (cookie + bearer)
 - **Session cookie**: `jp_admin_session` — HMAC-SHA256 signed, httpOnly, 30-min idle timeout
@@ -190,7 +190,7 @@ Routes are guarded via `src/lib/adminAuth.ts` middleware pattern. Route-level ac
 
 ### 5.2 Visitor OTP Flow
 
-OTP lifecycle is implemented in `src/services/authService.ts`. See also `docs/runbooks/otp-operational-policy.md` for operational runbook.
+OTP lifecycle is implemented in `src/services/authService.ts` (collection constants at lines 22-24, `OTP_MAX_FAILED_ATTEMPTS` at line 29, challenge persistence at lines 213-235, transactional validation at lines 244-366, session creation at lines 368-395, `requestOtpChallenge` at lines 654-835, `validateOtpChallengeRequest` at lines 837-995). See also `docs/runbooks/otp-operational-policy.md` for operational runbook.
 
 **Phase 1 — Challenge Request** (`POST /api/otp`):
 1. Use the provided email directly when present; otherwise resolve the visitor by cedula and fetch email from `users`

--- a/docs/runbooks/lighthouse-budget-rationale.md
+++ b/docs/runbooks/lighthouse-budget-rationale.md
@@ -6,8 +6,8 @@ These CI thresholds protect the public landing page without pretending GitHub Ac
 
 - Lighthouse runs in GitHub Actions on a cold browser/server start.
 - CI has no CDN, starts from a cold cache, and has no real edge/image optimization history.
-- The failing PR evidence for this slice showed CI LCP values between ~3366ms and ~3576ms even after the Phase 1 image work, so the CI ceiling must leave headroom for that environment instead of pretending it behaves like production.
-- The Phase 3 PR #36 follow-up showed CI TBT values at 230ms, 235.5ms, and 279ms, so the CI TBT ceiling also needs runner-specific headroom instead of pretending GitHub Actions consistently behaves like production hardware.
+- The failing PR evidence for this slice showed [UNVERIFIED] CI LCP values between ~3366ms and ~3576ms (observed historical snapshot, may drift run-to-run) even after the Phase 1 image work, so the CI ceiling must leave headroom for that environment instead of pretending it behaves like production.
+- The Phase 3 PR #36 follow-up showed [UNVERIFIED] CI TBT values at 230ms, 235.5ms, and 279ms (observed historical snapshot, may drift run-to-run), so the CI TBT ceiling also needs runner-specific headroom instead of pretending GitHub Actions consistently behaves like production hardware.
 - Production should still aim to beat these numbers consistently.
 
 ## Enforced CI thresholds


### PR DESCRIPTION
## Summary
Applies the minimal closeout slice for Phase 6.4–6.6 by tightening truthfulness markers and source traceability in the key reference docs before archive.

## Files changed
- `docs/reference/api.md`
- `docs/reference/architecture.md`
- `docs/runbooks/lighthouse-budget-rationale.md`
- `docs/reference/firebase.md`

## What changed
- marked drifting or historically observed claims as `[UNVERIFIED]`
- clarified that selected Lighthouse numbers are historical observations, not current reproducible benchmarks
- tightened source traceability for key reference areas
- corrected the API reference count from `6 schema files` to `7 schema/helper files`

## Verification
- ✅ `bun run check:docs` passes all blocking phases
- phase 4 drift shows 4 advisory `[UNVERIFIED]` markers exactly as intended

## Why this PR exists
This is the final tiny truthfulness closeout before archive: it reduces overclaiming without bloating docs or forcing fake evidence into the repo.

## Notes
Deferred on purpose:
- broad line-level traceability across every doc
- external validation evidence population
- any UX/code fixes for the WIG FAILs already documented elsewhere
