### PR TITLE
feat(portfolio): add external validation evidence scripts and reports

### DIFF
--- a/docs/portfolio/evidence/README.md
+++ b/docs/portfolio/evidence/README.md
@@ -23,21 +23,72 @@ This folder holds **real, reviewable evidence** for the public marketing surface
 
 ## Files in this folder
 
-| File | What it captures | Status |
-| --- | --- | --- |
-| `lighthouse-seo-report-placeholder.md` | Real Lighthouse (or PageSpeed Insights) run for the canonical public URL — score, LCP, TBT, CLS, and notes. | Empty template |
-| `rich-results-placeholder.md` | Rich Results Test / Schema.org validator output for the public JSON-LD. | Empty template |
-| `ai-citation-log-placeholder.md` | Monthly AI citation check (Google AI Overviews, ChatGPT, Perplexity) — one row per query. | Empty template |
-| `search-console-placeholder.md` | Google Search Console evidence that requires external account access (impressions, clicks, indexing). | Empty template |
+| File | What it captures | Automation | Status |
+|---|---|---|---|
+| `lighthouse-seo-report-placeholder.md` | PageSpeed Insights / Lighthouse scores (Performance, LCP, TBT, CLS, SEO) | Automated (`scripts/validate-pagespeed.ts`) | Pending — automated run rate-limited (needs `PSI_API_KEY`) |
+| `rich-results-placeholder.md` | Google Rich Results Test + JSON-LD extraction | Mixed (automated extraction + manual validator) | Pending — manual Rich Results Test not yet run. Automated extraction found 0 JSON-LD types. |
+| `schema-org-validator-placeholder.md` | Schema.org Validator output | Mixed (automated extraction + manual validator) | Pending — manual Schema.org validation not yet run. |
+| `search-console-placeholder.md` | Google Search Console (impressions, clicks, indexing) | Manual (requires account access) | Pending — manual export not yet performed. Instructions included. |
+| `ai-citation-log-placeholder.md` | Monthly AI citation check (Google, ChatGPT, Perplexity) | Manual (inherently manual — no citation APIs) | Pending — monthly check not yet run. 15-row template with queries included. |
+| `public-crawl-report.md` | Automated crawl: robots.txt, sitemap.xml, llms.txt, pricing.md | Automated (`scripts/validate-public-crawl.ts`) | ✅ Live — 2026-06-04 run: 4/4 checks passed |
+| `wcag-wig-report.md` | Playwright+Axe a11y audit + manual WCAG/WIG deep review | Mixed (automated Axe + manual review) | Partial — automated Axe run captured (2 passed, 2 violations). Manual deep review pending. |
+
+## Running the automation scripts
+
+### Individual scripts
+
+```bash
+# PageSpeed Insights (requires PSI_API_KEY for reliable results)
+bun run scripts/validate-pagespeed.ts -- --url=https://www.jumpingpark.lat
+
+# JSON-LD extraction
+bun run scripts/extract-jsonld.ts -- --url=https://www.jumpingpark.lat
+
+# Public crawl validation
+bun run scripts/validate-public-crawl.ts -- --url=https://www.jumpingpark.lat
+```
+
+### Full pipeline
+
+```bash
+# Run all 3 scripts in sequence (defaults to production URL)
+bun run validate:evidence
+
+# Override URL
+URL=https://staging.example.com bun run validate:evidence
+```
+
+### Accessibility (Playwright + Axe)
+
+```bash
+# Requires Firebase env vars for full page rendering
+bun run test:a11y:e2e
+```
 
 ## How to fill in a placeholder
 
-1. Run the validator or check the real source. Do not fabricate.
-2. Capture a screenshot or copy the raw report into the same commit. If the report is binary (HTML/JSON), store the raw file under a dated filename in this folder and link to it from the placeholder.
-3. Fill in the placeholder table with **only** what the validator actually returned. Leave a cell blank rather than guess.
-4. Add the run date, the URL tested, and any caveats in the `Notes` column.
-5. If a row contradicts a public claim in `README.md` or a runbook, treat that as a follow-up issue, not as something to quietly overwrite.
+1. **Check the Automation column above** — if "Automated," run the script first. If the script succeeds, paste its output. If it fails, record the failure honestly.
+2. **For manual validations**: Follow the step-by-step instructions embedded in each file. Each manual file contains:
+   - Exact URLs to test against
+   - Validator URLs (Rich Results Test, Schema.org, Search Console)
+   - A fillable table matching the validator's output shape
+   - Screenshot naming conventions
+3. Capture a screenshot or copy the raw report into the same commit. If the report is binary (HTML/JSON), store the raw file under a dated filename in this folder and link to it from the evidence file.
+4. Fill in the table with **only** what the validator actually returned. Leave a cell blank rather than guess.
+5. Add the run date, the URL tested, and any caveats in the `Notes` column.
+6. If a row contradicts a public claim in `README.md` or a runbook, treat that as a follow-up issue, not as something to quietly overwrite.
 
-## When a placeholder is still empty
+## When a file says "pending"
 
-Empty placeholders are intentional. They mark the **next honest thing to do** for portfolio readiness and prevent the folder from drifting into fake evidence. If a reviewer sees an empty table, the message is: "this run has not happened yet, do not treat the project as having this evidence."
+"Pending" is intentional and honest. It means: **this validation has not been performed yet** — do not treat the project as having this evidence until the file is populated with real data. Empty template rows are better than fake scores.
+
+### Current pending items (2026-06-04)
+
+| Validation | What's blocking | How to unblock |
+|---|---|---|
+| Lighthouse/PSI | Rate-limited (429). Anonymous quota exhausted. | Set `PSI_API_KEY` env var and rerun `validate-pagespeed.ts`. |
+| Rich Results Test | Manual browser run needed. | Open https://search.google.com/test/rich-results with canonical URL. |
+| Schema.org Validator | Manual browser run needed. | Open https://validator.schema.org/ with canonical URL. |
+| Search Console | Manual account access needed. | Follow export instructions in `search-console-placeholder.md`. |
+| AI citations | Manual monthly check needed. | Follow query instructions in `ai-citation-log-placeholder.md`. |
+| WCAG deep review | Manual inspection needed. | Follow the 45-check WCAG 2.1 AA matrix in `wcag-wig-report.md`. |

--- a/docs/portfolio/evidence/ai-citation-log-placeholder.md
+++ b/docs/portfolio/evidence/ai-citation-log-placeholder.md
@@ -1,38 +1,66 @@
 # AI citation log evidence
 
-This file is the **template** for the monthly AI citation check on the public marketing surface. It mirrors the table shape in `docs/ai-visibility-monthly-checklist.md` so the two stay aligned. It stays empty until a real monthly run is logged. Do not invent citations.
+This file is the **monthly AI citation check** log for the public marketing surface. It mirrors the table shape in `docs/ai-visibility-monthly-checklist.md`. It stays empty until a real monthly run is logged. Do **not** invent citations.
 
-## What real evidence looks like
+## Status: pending manual monthly check
 
-- One row per **query** (not per run). A month with five target queries produces five rows, one per platform.
-- The **actual platform** that was tested (Google AI Overviews, ChatGPT, Perplexity) and the **URL the platform cited**, if any.
-- A **screenshot or quoted snippet** of the model's answer, attached to the same commit. This is what makes the row auditable later.
-- The **month** the check was run, in `YYYY-MM` form, to keep this log roll-up-friendly with the runbook.
+This validation is inherently **manual** — AI platforms do not expose citation APIs, and their answers change with model updates. A monthly cadence with clean-session queries is the honest approach.
 
-## What does NOT count as evidence
+## Monthly check instructions
 
-- A "Jumping Park is now cited everywhere" summary without per-query rows.
-- A cited URL that was not actually shown by the platform in that run. If a citation is in a "related links" sidebar, the row still says no citation for the **answer body** — be precise.
-- A row from a query that is not in the runbook's recommended mix. If a new query is added, the runbook should be updated first; the evidence follows.
+### Platforms to check
 
-## Report template
+| Platform | How to test | Notes |
+|---|---|---|
+| **Google AI Overviews** | Search each query in Google (US results, incognito/clean session). Look for the AI-generated summary box at the top. | Google may not surface AI Overviews for all queries or regions. Note if it did not appear at all. |
+| **ChatGPT** | Use ChatGPT (free tier web, clean session). Ask each query. If using Search mode, enable it. | Record whether ChatGPT **cited** Jumping Park in the answer body, not just in a sidebar. |
+| **Perplexity** | Use perplexity.ai (free tier, clean session, "Web" focus). Ask each query. | Perplexity always cites sources. Record whether Jumping Park appears among them and in what position. |
+
+### Recommended query mix
+
+Use these queries (from `docs/ai-visibility-monthly-checklist.md`). If you add a new query, update the runbook first.
+
+| # | Query (Spanish) | Query (English) | Target page |
+|---|---|---|---|
+| 1 | consentimiento digital para parques de trampolines | digital consent for trampoline parks | `/consentimiento-digital` |
+| 2 | software gestión parques infantiles Colombia | kids park management software Colombia | `/` |
+| 3 | cómo gestionar consentimientos informados saltarines | how to manage informed consent trampoline parks | `/consentimiento-digital` |
+| 4 | precio software parque de saltos | trampoline park software pricing | `/pricing.md` |
+| 5 | cumplimiento legal parques infantiles digital | legal compliance digital kids parks | `/consentimiento-digital` |
+
+### Per-check steps
+
+1. **Pick the month** — use `YYYY-MM` format.
+2. **Run each query on each platform** with a clean session (incognito/private window).
+3. **Record only answer-body citations** — sidebar or "related links" are separate observations, not body citations.
+4. **If cited**: record the exact URL the platform surfaced.
+5. **If a competitor is cited instead**: record their URL in the `Competitor or third-party cited` column.
+6. **Take a screenshot** of the answer and save as `YYYY-MM-platform-query-N.png`.
+
+### Fill in the table
 
 | Month | Query | Platform | Cited? | Cited URL | Competitor or third-party cited | Notes / follow-up |
-| --- | --- | --- | --- | --- | --- | --- |
-| YYYY-MM |  | Google AI Overviews | Yes / No |  |  |  |
-| YYYY-MM |  | ChatGPT | Yes / No |  |  |  |
-| YYYY-MM |  | Perplexity | Yes / No |  |  |  |
+|---|---|---|---|---|---|---|
+| YYYY-MM | consentimiento digital para parques de trampolines | Google AI Overviews | Yes / No |  |  |  |
+| YYYY-MM | consentimiento digital para parques de trampolines | ChatGPT | Yes / No |  |  |  |
+| YYYY-MM | consentimiento digital para parques de trampolines | Perplexity | Yes / No |  |  |  |
+| YYYY-MM | software gestión parques infantiles Colombia | Google AI Overviews | Yes / No |  |  |  |
+| … | … | … | … | … | … | … |
 
-## How to fill a row
+*Repeat for all 5 queries × 3 platforms = 15 rows per month.*
 
-1. Pick the query from the runbook's recommended mix, or add it to the runbook first if the query is new.
-2. Run the query on the target platform with a clean session.
-3. Record whether the **answer body** cites Jumping Park. Treat a sidebar or "related links" only as a separate observation, not as a body citation.
-4. If cited, record the **exact URL** the platform surfaced. If a competitor or third party is cited instead, record that URL too.
-5. In `Notes`, capture: any drift from `/llms.txt` or `/pricing.md`, the public page that should be improved, and the issue link if a follow-up was opened.
-6. Attach the screenshot or quoted snippet to the same commit under a dated filename.
+### After filling
+
+- Commit all screenshots with the evidence rows.
+- If a page is never cited after 3 months, open an issue to improve `llms.txt`, `pricing.md`, or the page content.
+
+## What does NOT count
+
+- "Jumping Park is cited everywhere" without per-query rows.
+- A cited URL that was not actually shown by the platform in that run.
+- A row from a query not in the runbook (update the runbook first).
 
 ## Cross-references
 
-- `docs/ai-visibility-monthly-checklist.md` — the runbook, the recommended query mix, and the escalation rule.
-- `docs/runbooks/seo-ai-seo-validation-checklist.md` — the AI-SEO checks this log rolls up into.
+- `docs/ai-visibility-monthly-checklist.md` — the runbook (query mix, escalation rule).
+- `docs/runbooks/seo-ai-seo-validation-checklist.md` — AI-SEO checks this log rolls up into.

--- a/docs/portfolio/evidence/lighthouse-seo-report-placeholder.md
+++ b/docs/portfolio/evidence/lighthouse-seo-report-placeholder.md
@@ -1,36 +1,45 @@
 # Lighthouse SEO report evidence
 
-This file is the **template** for committed Lighthouse (or PageSpeed Insights) evidence for the public marketing surface. It stays empty until a real run is captured. Do not invent scores.
+This file captures real PageSpeed Insights (PSI) / Lighthouse runs for the canonical public URL. It stays populated with **real scores only** — never invented numbers.
 
-## What real evidence looks like
+## Automated run attempts
 
-- A **manual run** of Lighthouse (Chrome DevTools) or PageSpeed Insights against the canonical public URL listed in the runbook `docs/runbooks/seo-ai-seo-validation-checklist.md`.
-- A **screenshot** of the Lighthouse summary panel (Performance, Accessibility, Best Practices, SEO categories) or a copy/paste of the JSON report.
-- The **build/deploy commit SHA** that was live when the run was taken, so the result can be reproduced.
+| Date (UTC) | URL tested | Method | Performance | LCP (ms) | TBT (ms) | CLS | SEO | Notes |
+|---|---|---|---|---|---|---|---|---|
+| 2026-06-04T02:41 | https://www.jumpingpark.lat | PSI API (anonymous) | — | — | — | — | — | **Rate-limited**: HTTP 429 `RESOURCE_EXHAUSTED`. Anonymous daily quota exhausted. See failure details below. |
 
-## What does NOT count as evidence
+### Attempt #1 — 2026-06-04 failure details
 
-- Lighthouse CI artifacts. `lighthouserc.json` uploads to `temporary-public-storage`, which **expires**. Treat CI as a guardrail, not as a portfolio record. See `docs/runbooks/lighthouse-budget-rationale.md` for the CI-vs-production rationale.
-- A redacted or paraphrased score. If the panel said "0.82", the table says "0.82" — not "good", not "passing", not "✅".
-- A number from a different URL or environment than the one declared in the table.
+```
+HTTP 429 — Quota exceeded for quota metric 'Queries' and limit 'Queries per day'
+Service: pagespeedonline.googleapis.com
+Reason: RATE_LIMIT_EXCEEDED / RESOURCE_EXHAUSTED
+```
 
-## Report template
+**Fix**: Set `PSI_API_KEY` environment variable with a valid Google Cloud API key, then rerun:
+
+```bash
+PSI_API_KEY=your_key_here bun run scripts/validate-pagespeed.ts -- --url=https://www.jumpingpark.lat
+```
+
+## Manual run template
+
+Until an automated run succeeds with an API key, fill rows manually from a browser-based Lighthouse audit (Chrome DevTools → Lighthouse tab, or https://pagespeed.web.dev/).
 
 | Date | URL tested | Environment | Performance | LCP (ms) | TBT (ms) | CLS | SEO | Notes |
-| --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| YYYY-MM-DD | https://www.example.com/consentimiento-digital | production |  |  |  |  |  |  |
-| YYYY-MM-DD | https://www.example.com/consentimiento-digital | preview |  |  |  |  |  |  |
+|---|---|---|---|---|---|---|---|---|
+| YYYY-MM-DD | https://www.jumpingpark.lat/consentimiento-digital | production |  |  |  |  |  |  |
 
 ## How to fill a row
 
-1. Run Lighthouse or PageSpeed Insights against the URL with the same `PUBLIC_SEO_ENABLED` flag the production environment uses.
-2. Record the **four category scores** (Performance, Accessibility, Best Practices, SEO) as decimal numbers exactly as reported — do not round, do not invert.
+1. Run Lighthouse or PageSpeed Insights against the URL. For production, use `https://www.jumpingpark.lat/consentimiento-digital` (the only indexed page per sitemap as of 2026-06-04).
+2. Record the **four category scores** (Performance, Accessibility, Best Practices, SEO) as decimal numbers exactly as reported.
 3. Record LCP, TBT, and CLS in the units shown by the report (ms and unitless).
-4. In `Notes`, capture: deploy commit SHA, any deviation from the budget, and any warnings Lighthouse surfaced.
-5. Attach the screenshot or raw JSON to the same commit, under a dated filename (for example `2026-06-15-lighthouse-production.json`).
+4. In `Notes`, capture: deploy commit SHA, any deviation from budget, and any warnings Lighthouse surfaced.
+5. Attach the screenshot or raw JSON to the same commit, under a dated filename (e.g. `2026-06-15-lighthouse-production.json`).
 
 ## Cross-references
 
 - `docs/runbooks/seo-ai-seo-validation-checklist.md` — when to run Lighthouse and what to look for.
-- `docs/runbooks/lighthouse-budget-rationale.md` — why CI numbers are looser than production, and what production should aim for.
+- `docs/runbooks/lighthouse-budget-rationale.md` — why CI numbers are looser than production.
 - `lighthouserc.json` — CI thresholds only; do not paste CI JSON here.

--- a/docs/portfolio/evidence/public-crawl-report.md
+++ b/docs/portfolio/evidence/public-crawl-report.md
@@ -1,0 +1,75 @@
+# Public crawl report
+
+Automated validation of public-facing SEO and infrastructure assets. Run via `bun run scripts/validate-public-crawl.ts -- --url=<URL>`.
+
+## Latest automated run
+
+**Date**: 2026-06-04T02:41:11.191Z
+**URL**: https://www.jumpingpark.lat
+
+### JSON output
+
+```json
+{
+  "date": "2026-06-04T02:41:11.191Z",
+  "baseUrl": "https://www.jumpingpark.lat",
+  "checks": {
+    "robotsTxt": {
+      "status": 200,
+      "adminBlocked": true,
+      "pass": true
+    },
+    "sitemap": {
+      "status": 200,
+      "urlCount": 1,
+      "pass": true
+    },
+    "llmsTxt": {
+      "status": 200,
+      "hasContent": true,
+      "pass": true
+    },
+    "pricingMd": {
+      "status": 200,
+      "hasContent": true,
+      "pass": true
+    }
+  }
+}
+```
+
+### Results table
+
+| Asset | Status | Details | Pass |
+|---|---|---|---|
+| robots.txt | 200 | admin blocked: yes | ✅ |
+| sitemap.xml | 200 | 1 URL | ✅ |
+| llms.txt | 200 | has content: yes | ✅ |
+| pricing.md | 200 | has content: yes | ✅ |
+
+**Overall**: 4/4 checks passed.
+
+### Details
+
+- **robots.txt**: Returns 200 with `Disallow: /admin/` — admin area correctly blocked from crawlers.
+- **sitemap.xml**: Valid XML with 1 URL (`/consentimiento-digital`). Low URL count is expected for a single-page application with limited indexed routes.
+- **llms.txt**: Returns 200 with content — AI crawlers can discover the site's structured context.
+- **pricing.md**: Returns 200 with content — LLM-friendly pricing information is publicly accessible.
+
+## How to re-run
+
+```bash
+# Against production
+bun run scripts/validate-public-crawl.ts -- --url=https://www.jumpingpark.lat
+
+# Against local dev server
+bun run scripts/validate-public-crawl.ts -- --url=http://localhost:3000
+
+# As part of the full evidence pipeline
+bun run validate:evidence
+```
+
+## Cross-references
+
+- `scripts/validate-public-crawl.ts` — the automation script.
+- `docs/portfolio/evidence/README.md` — evidence folder overview.

--- a/docs/portfolio/evidence/rich-results-placeholder.md
+++ b/docs/portfolio/evidence/rich-results-placeholder.md
@@ -1,36 +1,47 @@
 # Rich Results / Schema.org validator evidence
 
-This file is the **template** for evidence from Google's Rich Results Test and the Schema.org Validator against the public JSON-LD. It stays empty until a real validation run is captured. Do not paste a "passing" badge that was not produced by the validator.
+This file captures evidence from Google's Rich Results Test and Schema.org Validator against the public JSON-LD. All data must come from **real validator runs** or be honestly marked "pending."
 
-## What real evidence looks like
+## Automated JSON-LD extraction
 
-- The **public URL** of the page that was tested (canonical, not a preview or staging URL).
-- The **raw output** from the Rich Results Test (detected structured data items, any warnings, any errors) and from the Schema.org Validator.
-- A **screenshot or copy/paste** of the validator result panel, attached to the same commit.
-- The **deploy commit SHA** that was live at the time of the run, so the result is reproducible.
+Run on 2026-06-04 against `https://www.jumpingpark.lat`:
 
-## What does NOT count as evidence
+```json
+{
+  "date": "2026-06-04T02:41:09.730Z",
+  "url": "https://www.jumpingpark.lat",
+  "types": [],
+  "blocks": []
+}
+```
 
-- A "no errors detected" claim without the underlying report. Schema.org and Rich Results can both show partial coverage with hidden warnings.
-- A run against a non-canonical URL (preview, staging, dev). Public discoverability is judged on the canonical URL only.
-- Re-running a stale local copy of the JSON-LD. Always re-validate the live page after a deploy.
+**Result**: No `<script type="application/ld+json">` blocks detected on the homepage. The homepage currently has **zero structured data markup**.
 
-## Report template
+> **Note**: The sitemap (2026-06-04) lists only one URL: `/consentimiento-digital`. Structured data may exist on that page but was not detected on the root. Re-run the extraction against the actual indexed page:
+
+```bash
+bun run scripts/extract-jsonld.ts -- --url=https://www.jumpingpark.lat/consentimiento-digital
+```
+
+## Manual Rich Results Test — pending
+
+This validation requires a **manual browser run** against the live page. The automated extraction above detected no JSON-LD, but a real validator may surface markup injected by client-side rendering.
+
+### Instructions
+
+1. Open **Google Rich Results Test**: https://search.google.com/test/rich-results
+2. Enter the canonical URL: `https://www.jumpingpark.lat/consentimiento-digital`
+3. Record every detected structured data type (e.g. `LocalBusiness`, `Organization`, `BreadcrumbList`).
+4. Record **all warnings and errors exactly as shown** — do not filter or paraphrase.
+5. Fill in the table below:
 
 | Date | URL tested | Validator | Detected types | Warnings | Errors | Notes |
-| --- | --- | --- | --- | --- | --- | --- |
-| YYYY-MM-DD | https://www.example.com/consentimiento-digital | Rich Results Test |  |  |  |  |
-| YYYY-MM-DD | https://www.example.com/consentimiento-digital | Schema.org Validator |  |  |  |  |
+|---|---|---|---|---|---|---|
+| YYYY-MM-DD | https://www.jumpingpark.lat/consentimiento-digital | Rich Results Test |  |  |  |  |
 
-## How to fill a row
-
-1. Open the validator with the canonical public URL.
-2. Record **every detected type** the validator surfaces (for example `LocalBusiness`, `BreadcrumbList`, `Organization`). Do not summarise — list them so a reviewer can confirm coverage.
-3. Record warnings and errors **as written by the validator**, even if the page still validates overall. A warning is a signal, not a decoration.
-4. In `Notes`, capture: deploy commit SHA, whether the run matched the public narrative, and any follow-up needed.
-5. Attach the raw validator output (HTML or JSON) to the same commit under a dated filename.
+6. Take a **screenshot** of the result panel and save as `YYYY-MM-DD-rich-results.png` in this folder.
 
 ## Cross-references
 
-- `docs/runbooks/seo-ai-seo-validation-checklist.md` — what the project commits to validating on the public surface.
-- `docs/portfolio/evidence/README.md` — anti-patterns for committed evidence (no invented pass/fail).
+- `docs/runbooks/seo-ai-seo-validation-checklist.md` — validation cadence and pass criteria.
+- `docs/portfolio/evidence/README.md` — anti-patterns for committed evidence.

--- a/docs/portfolio/evidence/schema-org-validator-placeholder.md
+++ b/docs/portfolio/evidence/schema-org-validator-placeholder.md
@@ -1,0 +1,49 @@
+# Schema.org Validator evidence
+
+This file captures Schema.org Validator evidence for the public JSON-LD. It is a **companion** to `rich-results-placeholder.md` — Rich Results Test checks Google-specific eligibility, while Schema.org validates universal structured data correctness.
+
+## Automated JSON-LD extraction (same run as rich-results)
+
+Run on 2026-06-04 against `https://www.jumpingpark.lat`:
+
+```json
+{
+  "date": "2026-06-04T02:41:09.730Z",
+  "url": "https://www.jumpingpark.lat",
+  "types": [],
+  "blocks": []
+}
+```
+
+**Result**: No JSON-LD detected on the homepage.
+
+## Manual Schema.org validation — pending
+
+### Instructions
+
+1. Open **Schema.org Validator**: https://validator.schema.org/
+2. Enter the canonical URL: `https://www.jumpingpark.lat/consentimiento-digital`
+3. Select the **"Fetch URL"** tab (validates the live page).
+4. Record:
+   - **Every `@type` detected** — list them fully, do not summarise.
+   - **Warnings** — copy verbatim. A warning is a signal, not a decoration.
+   - **Errors** — copy verbatim.
+5. Fill in the table:
+
+| Date | URL tested | Validator | Detected types | Warnings | Errors | Notes |
+|---|---|---|---|---|---|---|
+| YYYY-MM-DD | https://www.jumpingpark.lat/consentimiento-digital | Schema.org Validator |  |  |  |  |
+
+6. Take a **screenshot** and save as `YYYY-MM-DD-schema-org-validator.png`.
+7. If the page has no structured data at all, the table row should say `(none)` under types and `—` under warnings/errors. That is honest evidence.
+
+## What does NOT count
+
+- A "validates without errors" claim without the underlying validator report.
+- A run against a different URL than the canonical indexed page.
+- Re-validating a stale local copy of the JSON-LD. Always validate the **live deployed page**.
+
+## Cross-references
+
+- `rich-results-placeholder.md` — Google-specific structured data eligibility (same folder).
+- `docs/runbooks/seo-ai-seo-validation-checklist.md` — validator cadence and criteria.

--- a/docs/portfolio/evidence/search-console-placeholder.md
+++ b/docs/portfolio/evidence/search-console-placeholder.md
@@ -1,36 +1,57 @@
 # Search Console evidence
 
-This file is the **template** for Google Search Console evidence that requires external account access. It stays empty until a real Search Console export is captured. Do not invent impressions, clicks, or indexing state.
+This file captures Google Search Console evidence that requires **external account access**. It stays empty until a real Search Console export is captured. Do **not** invent impressions, clicks, or indexing state.
 
-## What real evidence looks like
+## Status: pending manual export
 
-- A **date range** that matches a real Search Console query (default is the last 28 days, or the current month).
-- The **URL or property** the export came from, so the row can be matched to the canonical public surface.
-- The **raw numbers** as Search Console reports them — impressions, clicks, average position, and indexing status. Do not invert or round.
-- A **screenshot of the Search Console panel** or a CSV/Excel export, attached to the same commit. The export is what makes the row auditable later.
+**This validation cannot be automated** without OAuth2 integration for the Search Console API. The project currently uses manual exports, which is sufficient for portfolio purposes.
 
-## What does NOT count as evidence
+## Step-by-step export instructions
 
-- A summary like "everything is indexed" without the underlying report. Indexing exceptions are the most important signal in Search Console; they are easy to miss and easy to fake.
-- Numbers copied from a third-party SEO tool. The project commits to **Search Console as the source of truth** for indexing and click data.
-- A row from a property that is not the canonical public property (for example a staging or dev property).
+### Prerequisites
 
-## Report template
+- A Google account with **Owner** or **Full User** access to the Search Console property `https://www.jumpingpark.lat/`.
+- The property must be verified (DNS TXT record, HTML file, or Google Analytics).
+
+### Steps
+
+1. **Open Search Console**: https://search.google.com/search-console
+2. Select the property: `https://www.jumpingpark.lat/` (or `sc-domain:jumpingpark.lat` for domain-level).
+3. **Performance report**:
+   - Go to **Performance** → set date range to last 28 days.
+   - Record: Total clicks, Total impressions, Average CTR, Average position.
+   - Click **Export** → download as CSV.
+4. **Indexing report**:
+   - Go to **Pages** → see "Indexed" and "Not indexed" counts.
+   - Click on "Not indexed" to review exclusion reasons.
+   - Note any unexpected exclusions (e.g. `Excluded by 'noindex' tag`, `Crawled - currently not indexed`).
+5. **Sitemap status** (if submitted):
+   - Go to **Sitemaps** → check last read date and any errors.
+6. **Manual actions & Security issues**:
+   - Check both tabs under **Security & Manual Actions**. Should be empty.
+
+### Fill in the evidence table
 
 | Date range | Property | Impressions | Clicks | Avg. position | Indexed pages | Excluded pages | Notes |
-| --- | --- | --- | --- | --- | --- | --- | --- |
-| YYYY-MM-DD to YYYY-MM-DD | https://www.example.com/ |  |  |  |  |  |  |
+|---|---|---|---|---|---|---|---|
+| YYYY-MM-DD to YYYY-MM-DD | https://www.jumpingpark.lat/ |  |  |  |  |  |  |
 
-## How to fill a row
+### After filling
 
-1. Open Search Console for the canonical public property.
-2. Run the Performance report for the chosen date range. Use the default **Web** search type unless the runbook says otherwise.
-3. Run the **Pages > Indexing** report and record both indexed and excluded counts. Excluded pages are not a failure by themselves — note any unexpected exclusions in the `Notes` column.
-4. Record the raw totals as Search Console reports them. Do not normalise to per-day averages.
-5. In `Notes`, capture: any manual actions, any crawl anomalies, the deploy commit SHA the report window covers, and any follow-up issue opened.
-6. Attach the screenshot or CSV export to the same commit under a dated filename.
+- Save the CSV export as `YYYY-MM-DD-search-console-performance.csv` in this folder.
+- Take a screenshot of the **Pages → Indexing** panel and save as `YYYY-MM-DD-search-console-indexing.png`.
+- In `Notes`, record:
+  - The deploy commit SHA the report window covers.
+  - Any manual actions or crawl anomalies.
+  - Any follow-up issue opened for unexpected exclusions.
+
+## What does NOT count
+
+- Numbers from a third-party SEO tool (Ahrefs, SEMrush, etc.). Search Console is the source of truth.
+- A row from a staging or dev property.
+- A summary like "everything is indexed" without the underlying CSV or screenshot.
 
 ## Cross-references
 
-- `docs/runbooks/seo-ai-seo-validation-checklist.md` — the indexability checks this evidence rolls up into.
-- `docs/portfolio/evidence/README.md` — anti-patterns for committed evidence (no fake green checks).
+- `docs/runbooks/seo-ai-seo-validation-checklist.md` — indexability checks.
+- `docs/portfolio/evidence/README.md` — evidence anti-patterns.

--- a/docs/portfolio/evidence/wcag-wig-report.md
+++ b/docs/portfolio/evidence/wcag-wig-report.md
@@ -1,0 +1,94 @@
+# WCAG / WIG accessibility evidence
+
+This file captures automated accessibility (Axe) audit results from Playwright E2E tests, plus a **manual deep WCAG/WIG review** section. Automated results are real — manual results must be honestly marked "pending" until performed.
+
+## Automated Axe audit (Playwright E2E)
+
+**Date**: 2026-06-04
+**Tool**: Playwright 1.59.1 + @axe-core/playwright 4.11.1
+**Test file**: `playwright/accessibility.a11y.ts`
+
+### Results summary
+
+| Test | Route | Axe passed | Reflow (640px) | Notes |
+|---|---|---|---|---|
+| Public consentimiento digital | `/consentimiento-digital` | ❓ (page not rendered) | ❓ | Test failed — page content not visible. Likely missing Firebase env vars in local dev. |
+| Kiosk consent dialog | `/consentimiento` | ✅ | N/A | Dialog keyboard trap test passed. Zero Axe violations inside `[role="dialog"]`. |
+| Kiosk ingreso | `/ingreso` | ❓ (page not rendered) | ❓ | Test failed — heading not found. Likely missing Firebase env vars. |
+| Kiosk home | `/` | ❌ (1 violation) | ✅ | `meta-viewport` violation detected. No horizontal overflow. |
+| Offline page | `/offline` | ❌ (3 violations) | ✅ | `landmark-one-main`, `meta-viewport`, `region` violations. No horizontal overflow. |
+| Admin login | `/admin/login` | ❓ (locator error) | ❓ | Test failed — strict mode violation on password label selector. Not an Axe issue. |
+| Kiosk registro | `/registro` | ⏭️ skipped | ⏭️ skipped | Guarded route — form not rendered without active session. |
+| Signature canvas a11y | `/consentimiento` (signature) | ✅ | N/A | `willReadFrequently` canvas fix verified. |
+
+**Passed**: 2/8 tests
+**Axe violations found**: `meta-viewport` (kiosk home, offline), `landmark-one-main` (offline), `region` (offline)
+
+### Detailed violation findings
+
+#### meta-viewport
+- **Impact**: critical
+- **Affected pages**: Kiosk home (`/`), Offline page (`/offline`)
+- **Description**: Page does not have a `<meta name="viewport">` tag with `width` or `initial-scale`. This prevents mobile browsers from scaling correctly and users from zooming.
+- **Fix**: Add `<meta name="viewport" content="width=device-width, initial-scale=1">` to the root layout or affected page layouts.
+
+#### landmark-one-main
+- **Impact**: moderate
+- **Affected page**: Offline page (`/offline`)
+- **Description**: Page does not have a `<main>` landmark. All content should be contained within a main landmark for assistive technology navigation.
+- **Fix**: Wrap page body content in `<main>` element.
+
+#### region
+- **Impact**: moderate
+- **Affected page**: Offline page (`/offline`)
+- **Description**: Content not contained within a landmark region. Some page content resides outside any ARIA landmark.
+- **Fix**: Ensure all perceivable content is inside a landmark region (`<main>`, `<nav>`, `<header>`, `<footer>`, etc.).
+
+### Test failures (non-Axe reasons)
+
+Some tests failed because the local dev server lacked Firebase environment variables (`FIREBASE_PROJECT_ID`, `FIREBASE_CLIENT_EMAIL`, `FIREBASE_PRIVATE_KEY`), causing pages not to render. These failures are **environment-related, not accessibility issues**. To get full Axe coverage:
+
+```bash
+# Set Firebase env vars, then re-run
+FIREBASE_PROJECT_ID=xxx FIREBASE_CLIENT_EMAIL=xxx FIREBASE_PRIVATE_KEY=xxx bun run test:a11y:e2e
+```
+
+## Manual deep WCAG/WIG review — pending
+
+The automated Axe audit catches ~30-40% of WCAG 2.1 AA issues. A full WCAG 2.1 AA / WIG (Web Accessibility Initiative Guidelines) review requires **manual inspection** by a human reviewer.
+
+### Instructions for manual review
+
+1. **Reference**: WCAG 2.1 AA at https://www.w3.org/TR/WCAG21/
+2. **Pages to review** (in order of priority):
+   - `/consentimiento-digital` — public landing page (SEO-critical)
+   - `/ingreso` — kiosk check-in flow
+   - `/consentimiento` — kiosk consent flow
+   - `/registro` — registration form
+   - `/admin/login` — admin authentication
+3. **Checklist per page**:
+   - [ ] **1.1.1 Non-text Content**: All images have meaningful `alt` text. Decorative images have `alt=""`.
+   - [ ] **1.3.1 Info and Relationships**: Form labels are programmatically associated with inputs. Heading hierarchy is logical (no skipped levels).
+   - [ ] **1.4.3 Contrast (Minimum)**: Text has 4.5:1 contrast ratio against background. Large text has 3:1.
+   - [ ] **1.4.4 Resize Text**: Page is usable at 200% zoom without horizontal scrolling.
+   - [ ] **2.1.1 Keyboard**: All interactive elements are reachable and operable via keyboard alone.
+   - [ ] **2.4.3 Focus Order**: Focus moves in a logical order through the page.
+   - [ ] **2.4.7 Focus Visible**: Keyboard focus indicator is visible on all interactive elements.
+   - [ ] **3.3.2 Labels or Instructions**: All form inputs have visible labels.
+   - [ ] **4.1.2 Name, Role, Value**: Interactive elements expose correct names, roles, and values to assistive technology.
+4. **Record findings**:
+
+| WCAG SC | Page | Pass/Fail | Notes |
+|---|---|---|---|
+| 1.1.1 | /consentimiento-digital |  |  |
+| 1.3.1 | /consentimiento-digital |  |  |
+| 1.4.3 | /consentimiento-digital |  |  |
+| … | … | … | … |
+
+5. **Fill the full matrix for ALL 9 success criteria × ALL 5 pages = 45 checks**.
+
+## Cross-references
+
+- `playwright/accessibility.a11y.ts` — automated Axe test file.
+- `docs/reference/accessibility.md` — accessibility route matrix (Phase 6.2).
+- `docs/portfolio/evidence/README.md` — evidence anti-patterns.

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "screenshot:capture": "bun run scripts/capture-screenshots.ts",
     "optimize:images": "bun run scripts/optimize-images.ts",
     "optimize:screenshots": "bun run scripts/optimize-screenshots.ts",
-    "backup": "bun run scripts/backup.ts"
+    "backup": "bun run scripts/backup.ts",
+    "validate:evidence": "bun run scripts/validate-pagespeed.ts -- --url ${URL:-https://www.jumpingpark.lat} && bun run scripts/extract-jsonld.ts -- --url ${URL:-https://www.jumpingpark.lat} && bun run scripts/validate-public-crawl.ts -- --url ${URL:-https://www.jumpingpark.lat}"
   },
   "dependencies": {
     "@hookform/resolvers": "^5.2.2",

--- a/scripts/extract-jsonld.ts
+++ b/scripts/extract-jsonld.ts
@@ -1,0 +1,99 @@
+/**
+ * extract-jsonld — Fetches a public URL and extracts JSON-LD structured data.
+ *
+ * Usage: bun run scripts/extract-jsonld.ts --url <URL>
+ *
+ * Outputs detected schema types + raw JSON to stdout. Exits 1 on failure.
+ */
+
+const JSON_LD_REGEX = /<script\s+[^>]*type\s*=\s*["']application\/ld\+json["'][^>]*>([\s\S]*?)<\/script>/gi
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function extractTypes(obj: Record<string, unknown>): string[] {
+  const raw = obj['@type']
+  if (!raw) return []
+  if (Array.isArray(raw)) return raw.map((t) => String(t))
+  return [String(raw)]
+}
+
+export interface JsonLdExtraction {
+  date: string
+  url: string
+  types: string[]
+  blocks: Record<string, unknown>[]
+}
+
+export async function extractJsonLd(url: string): Promise<JsonLdExtraction> {
+  const response = await fetch(url)
+  if (!response.ok) {
+    throw new Error(
+      `Fetch returned HTTP ${String(response.status)} for ${url}`,
+    )
+  }
+
+  const html = await response.text()
+  const blocks: Record<string, unknown>[] = []
+  const types: string[] = []
+
+  let match: RegExpExecArray | null
+  JSON_LD_REGEX.lastIndex = 0
+  while ((match = JSON_LD_REGEX.exec(html)) !== null) {
+    const raw = match[1].trim()
+    try {
+      const parsed: unknown = JSON.parse(raw)
+      if (!isRecord(parsed)) {
+        throw new Error('JSON-LD block is not an object')
+      }
+      blocks.push(parsed)
+      types.push(...extractTypes(parsed))
+    } catch {
+      throw new Error(
+        `Malformed JSON in JSON-LD block at position ${String(match.index)}`,
+      )
+    }
+  }
+
+  return {
+    date: new Date().toISOString(),
+    url,
+    types,
+    blocks,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// CLI entry point
+// ---------------------------------------------------------------------------
+
+if (import.meta.main) {
+  const urlArg = Bun.argv.find((a) => a.startsWith('--url='))?.split('=')[1]
+  if (!urlArg) {
+    console.error('[extract-jsonld] Missing --url parameter')
+    process.exit(1)
+  }
+
+  extractJsonLd(urlArg)
+    .then((result) => {
+      console.log(JSON.stringify(result, null, 2))
+      console.log()
+      console.log('| Schema Type     | Detected |')
+      console.log('|-----------------|----------|')
+      if (result.types.length === 0) {
+        console.log('| (none)          | ❌       |')
+      } else {
+        for (const t of result.types) {
+          console.log(`| ${t} | ✅ |`)
+        }
+      }
+    })
+    .catch((error: unknown) => {
+      console.error(
+        '[extract-jsonld]',
+        error instanceof Error ? error.message : String(error),
+      )
+      process.exit(1)
+    })
+}

--- a/scripts/validate-pagespeed.ts
+++ b/scripts/validate-pagespeed.ts
@@ -1,0 +1,123 @@
+/**
+ * validate-pagespeed — Calls PageSpeed Insights API for a given URL.
+ *
+ * Usage: bun run scripts/validate-pagespeed.ts --url <URL>
+ * Env:   PSI_API_KEY (optional — uses anonymous quota if absent)
+ *
+ * Outputs JSON + markdown table to stdout. Exits 1 on failure.
+ */
+
+const PSI_BASE = 'https://www.googleapis.com/pagespeedonline/v5/runPagespeed'
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function getScore(
+  obj: Record<string, unknown>,
+  key: string,
+): number {
+  const entry = obj[key]
+  if (!isRecord(entry)) return 0
+  const score = entry['score']
+  return typeof score === 'number' ? score : 0
+}
+
+function getNumericValue(
+  obj: Record<string, unknown>,
+  key: string,
+): number {
+  const entry = obj[key]
+  if (!isRecord(entry)) return 0
+  const val = entry['numericValue']
+  return typeof val === 'number' ? val : 0
+}
+
+export interface PSIResult {
+  date: string
+  url: string
+  strategy: 'mobile' | 'desktop'
+  performance: number
+  lcp: number
+  tbt: number
+  cls: number
+  seo: number
+}
+
+export async function runPagespeed(
+  url: string,
+  apiKey?: string,
+): Promise<PSIResult> {
+  const params = new URLSearchParams({ url, strategy: 'mobile' })
+  if (apiKey) params.set('key', apiKey)
+  const endpoint = `${PSI_BASE}?${params.toString()}`
+
+  const response = await fetch(endpoint)
+  if (!response.ok) {
+    throw new Error(
+      `PSI API returned HTTP ${String(response.status)}: ${await response.text()}`,
+    )
+  }
+
+  const rawData: unknown = await response.json()
+  if (!isRecord(rawData)) {
+    throw new Error('PSI API returned unexpected response shape')
+  }
+
+  const lh = isRecord(rawData['lighthouseResult'])
+    ? rawData['lighthouseResult']
+    : undefined
+  const rawCategories = lh && isRecord(lh['categories']) ? lh['categories'] : undefined
+  const rawAudits = lh && isRecord(lh['audits']) ? lh['audits'] : undefined
+  const categories: Record<string, unknown> = rawCategories ?? {}
+  const audits: Record<string, unknown> = rawAudits ?? {}
+
+  const performance = Math.round(getScore(categories, 'performance') * 100)
+  const seo = Math.round(getScore(categories, 'seo') * 100)
+  const lcp = getNumericValue(audits, 'largest-contentful-paint')
+  const tbt = getNumericValue(audits, 'total-blocking-time')
+  const cls = getNumericValue(audits, 'cumulative-layout-shift')
+
+  return {
+    date: new Date().toISOString(),
+    url,
+    strategy: 'mobile',
+    performance,
+    lcp,
+    tbt,
+    cls,
+    seo,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// CLI entry point
+// ---------------------------------------------------------------------------
+
+if (import.meta.main) {
+  const urlArg = Bun.argv.find((a) => a.startsWith('--url='))?.split('=')[1]
+  if (!urlArg) {
+    console.error('[validate-pagespeed] Missing --url parameter')
+    process.exit(1)
+  }
+
+  runPagespeed(urlArg, process.env.PSI_API_KEY)
+    .then((result) => {
+      console.log(JSON.stringify(result, null, 2))
+      console.log()
+      console.log('| Metric      | Value |')
+      console.log('|-------------|-------|')
+      console.log(`| Performance | ${String(result.performance)}/100 |`)
+      console.log(`| LCP         | ${String(result.lcp)}ms |`)
+      console.log(`| TBT         | ${String(result.tbt)}ms |`)
+      console.log(`| CLS         | ${String(result.cls)} |`)
+      console.log(`| SEO         | ${String(result.seo)}/100 |`)
+    })
+    .catch((error: unknown) => {
+      console.error(
+        '[validate-pagespeed]',
+        error instanceof Error ? error.message : String(error),
+      )
+      process.exit(1)
+    })
+}

--- a/scripts/validate-public-crawl.ts
+++ b/scripts/validate-public-crawl.ts
@@ -1,0 +1,154 @@
+/**
+ * validate-public-crawl — Checks public-facing SEO/infrastructure assets.
+ *
+ * Usage: bun run scripts/validate-public-crawl.ts --url <BASE_URL>
+ *
+ * Validates:
+ *   - robots.txt   (200, admin area blocked)
+ *   - sitemap.xml  (valid XML, url count)
+ *   - llms.txt     (exists, has content)
+ *   - pricing.md   (exists, has content)
+ *
+ * Outputs JSON + markdown table to stdout. Exits 1 if any critical check fails.
+ */
+
+interface CheckResult {
+  status: number
+  pass: boolean
+}
+
+interface RobotsCheck extends CheckResult {
+  adminBlocked: boolean
+}
+
+interface SitemapCheck extends CheckResult {
+  urlCount: number
+}
+
+interface ContentCheck extends CheckResult {
+  hasContent: boolean
+}
+
+export interface CrawlResult {
+  date: string
+  baseUrl: string
+  checks: {
+    robotsTxt: RobotsCheck
+    sitemap: SitemapCheck
+    llmsTxt: ContentCheck
+    pricingMd: ContentCheck
+  }
+}
+
+function normalizeUrl(baseUrl: string): string {
+  return baseUrl.endsWith('/') ? baseUrl.slice(0, -1) : baseUrl
+}
+
+async function fetchSafe(url: string): Promise<{ status: number; body: string }> {
+  try {
+    const response = await fetch(url)
+    return { status: response.status, body: await response.text() }
+  } catch {
+    return { status: 0, body: '' }
+  }
+}
+
+async function checkRobots(baseUrl: string): Promise<RobotsCheck> {
+  const { status, body } = await fetchSafe(`${baseUrl}/robots.txt`)
+  const adminBlocked = /^\s*Disallow\s*:\s*\/admin\//im.test(body)
+  return { status, adminBlocked, pass: status === 200 && adminBlocked }
+}
+
+async function checkSitemap(baseUrl: string): Promise<SitemapCheck> {
+  const { status, body } = await fetchSafe(`${baseUrl}/sitemap.xml`)
+  let urlCount = 0
+  let validXml = false
+  if (status === 200 && body.length > 0) {
+    try {
+      const urlMatches = body.match(/<url>/g)
+      urlCount = urlMatches ? urlMatches.length : 0
+      validXml = body.includes('<?xml') || body.includes('<urlset') || body.includes('<sitemapindex')
+    } catch {
+      // invalid XML
+    }
+  }
+  return { status, urlCount, pass: status === 200 && validXml }
+}
+
+async function checkContentAsset(
+  baseUrl: string,
+  path: string,
+): Promise<ContentCheck> {
+  const { status, body } = await fetchSafe(`${baseUrl}/${path}`)
+  const hasContent = status === 200 && body.trim().length > 0
+  return { status, hasContent, pass: hasContent }
+}
+
+async function checkLlmTxt(baseUrl: string): Promise<ContentCheck> {
+  return checkContentAsset(baseUrl, 'llms.txt')
+}
+
+async function checkPricingMd(baseUrl: string): Promise<ContentCheck> {
+  return checkContentAsset(baseUrl, 'pricing.md')
+}
+
+export async function runCrawl(baseUrl: string): Promise<CrawlResult> {
+  const normalized = normalizeUrl(baseUrl)
+
+  const [robotsTxt, sitemap, llmsTxt, pricingMd] = await Promise.all([
+    checkRobots(normalized),
+    checkSitemap(normalized),
+    checkLlmTxt(normalized),
+    checkPricingMd(normalized),
+  ])
+
+  return {
+    date: new Date().toISOString(),
+    baseUrl: normalized,
+    checks: { robotsTxt, sitemap, llmsTxt, pricingMd },
+  }
+}
+
+// ---------------------------------------------------------------------------
+// CLI entry point
+// ---------------------------------------------------------------------------
+
+if (import.meta.main) {
+  const urlArg = Bun.argv.find((a) => a.startsWith('--url='))?.split('=')[1]
+  if (!urlArg) {
+    console.error('[validate-public-crawl] Missing --url parameter')
+    process.exit(1)
+  }
+
+  runCrawl(urlArg)
+    .then((result) => {
+      console.log(JSON.stringify(result, null, 2))
+      console.log()
+      console.log('| Asset        | Status | Details          | Pass |')
+      console.log('|--------------|--------|------------------|------|')
+      console.log(
+        `| robots.txt   | ${String(result.checks.robotsTxt.status)} | admin blocked: ${result.checks.robotsTxt.adminBlocked ? 'yes' : 'no'} | ${result.checks.robotsTxt.pass ? '✅' : '❌'} |`,
+      )
+      console.log(
+        `| sitemap.xml  | ${String(result.checks.sitemap.status)} | ${String(result.checks.sitemap.urlCount)} URLs | ${result.checks.sitemap.pass ? '✅' : '❌'} |`,
+      )
+      console.log(
+        `| llms.txt     | ${String(result.checks.llmsTxt.status)} | has content: ${result.checks.llmsTxt.hasContent ? 'yes' : 'no'} | ${result.checks.llmsTxt.pass ? '✅' : '❌'} |`,
+      )
+      console.log(
+        `| pricing.md   | ${String(result.checks.pricingMd.status)} | has content: ${result.checks.pricingMd.hasContent ? 'yes' : 'no'} | ${result.checks.pricingMd.pass ? '✅' : '❌'} |`,
+      )
+
+      const allPassed = Object.values(result.checks).every((c) => c.pass)
+      if (!allPassed) {
+        process.exit(1)
+      }
+    })
+    .catch((error: unknown) => {
+      console.error(
+        '[validate-public-crawl]',
+        error instanceof Error ? error.message : String(error),
+      )
+      process.exit(1)
+    })
+}

--- a/tests/evidence-scripts.test.ts
+++ b/tests/evidence-scripts.test.ts
@@ -1,0 +1,425 @@
+import { beforeAll, describe, expect, it, mock } from 'bun:test'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function mockFetch(impl: (_input: string | URL | Request, _init?: RequestInit) => Promise<Response>) {
+  mock.module('node:http', () => ({})) // prevent real network in Bun test
+  globalThis.fetch = impl as typeof globalThis.fetch
+}
+
+function makeJsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  })
+}
+
+function makeTextResponse(body: string, status = 200): Response {
+  return new Response(body, {
+    status,
+    headers: { 'content-type': 'text/plain' },
+  })
+}
+
+function makeHtmlResponse(body: string, status = 200): Response {
+  return new Response(body, {
+    status,
+    headers: { 'content-type': 'text/html' },
+  })
+}
+
+function makeXmlResponse(body: string, status = 200): Response {
+  return new Response(body, {
+    status,
+    headers: { 'content-type': 'application/xml' },
+  })
+}
+
+function makeMdResponse(body: string, status = 200): Response {
+  return new Response(body, {
+    status,
+    headers: { 'content-type': 'text/markdown' },
+  })
+}
+
+// ---------------------------------------------------------------------------
+// 1.1 validate-pagespeed.ts
+// ---------------------------------------------------------------------------
+
+describe('validate-pagespeed', () => {
+  let runPagespeed: (url: string, apiKey?: string) => Promise<{
+    date: string
+    url: string
+    strategy: string
+    performance: number
+    lcp: number
+    tbt: number
+    cls: number
+    seo: number
+  }>
+
+  beforeAll(async () => {
+    const mod = await import('../scripts/validate-pagespeed')
+    runPagespeed = mod.runPagespeed
+  })
+
+  it('returns PSI scores when API responds with valid data', async () => {
+    const mockResponse = {
+      lighthouseResult: {
+        categories: {
+          performance: { score: 0.92 },
+          seo: { score: 0.85 },
+        },
+        audits: {
+          'largest-contentful-paint': { numericValue: 1200 },
+          'total-blocking-time': { numericValue: 45 },
+          'cumulative-layout-shift': { numericValue: 0.03 },
+        },
+      },
+    }
+
+    mockFetch(async (_input: string | URL | Request, _init?: RequestInit) =>
+      makeJsonResponse(mockResponse),
+    )
+
+    const result = await runPagespeed('https://example.com', 'fake-key')
+
+    expect(result.performance).toBe(92)
+    expect(result.lcp).toBe(1200)
+    expect(result.tbt).toBe(45)
+    expect(result.cls).toBe(0.03)
+    expect(result.seo).toBe(85)
+    expect(result.url).toBe('https://example.com')
+    expect(result.strategy).toBe('mobile')
+    expect(result.date).toBeTruthy()
+  })
+
+  it('handles missing API key gracefully (anonymous quota path)', async () => {
+    const mockResponse = {
+      lighthouseResult: {
+        categories: {
+          performance: { score: 0.78 },
+          seo: { score: 0.90 },
+        },
+        audits: {
+          'largest-contentful-paint': { numericValue: 2500 },
+          'total-blocking-time': { numericValue: 120 },
+          'cumulative-layout-shift': { numericValue: 0.01 },
+        },
+      },
+    }
+
+    mockFetch(async (_input: string | URL | Request, _init?: RequestInit) =>
+      makeJsonResponse(mockResponse),
+    )
+
+    const result = await runPagespeed('https://example.com')
+
+    expect(result.performance).toBe(78)
+    expect(result.seo).toBe(90)
+    expect(result.strategy).toBe('mobile')
+  })
+
+  it('throws error when PSI API returns non-200', async () => {
+    mockFetch(async (_input: string | URL | Request, _init?: RequestInit) =>
+      makeJsonResponse({ error: { message: 'Quota exceeded' } }, 429),
+    )
+
+    await expect(runPagespeed('https://example.com', 'fake-key')).rejects.toThrow(
+      /429/,
+    )
+  })
+
+  it('throws error on network failure', async () => {
+    mockFetch(async (_input: string | URL | Request, _init?: RequestInit) => {
+      throw new Error('ECONNREFUSED')
+    })
+
+    await expect(runPagespeed('https://example.com')).rejects.toThrow(
+      /ECONNREFUSED/,
+    )
+  })
+})
+
+// ---------------------------------------------------------------------------
+// 1.2 extract-jsonld.ts
+// ---------------------------------------------------------------------------
+
+describe('extract-jsonld', () => {
+  let extractJsonLd: (url: string) => Promise<{
+    date: string
+    url: string
+    types: string[]
+    blocks: unknown[]
+  }>
+
+  beforeAll(async () => {
+    const mod = await import('../scripts/extract-jsonld')
+    extractJsonLd = mod.extractJsonLd
+  })
+
+  it('extracts JSON-LD blocks from valid HTML', async () => {
+    const html = `
+      <html>
+      <head>
+        <script type="application/ld+json">
+          {"@context":"https://schema.org","@type":"LocalBusiness","name":"Jumping Park"}
+        </script>
+      </head>
+      <body>
+        <script type="application/ld+json">
+          {"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[]}
+        </script>
+      </body>
+      </html>
+    `
+
+    mockFetch(async (_input: string | URL | Request, _init?: RequestInit) =>
+      makeHtmlResponse(html),
+    )
+
+    const result = await extractJsonLd('https://example.com')
+
+    expect(result.types).toContain('LocalBusiness')
+    expect(result.types).toContain('BreadcrumbList')
+    expect(result.blocks).toHaveLength(2)
+    expect(result.blocks[0]).toHaveProperty('@type', 'LocalBusiness')
+    expect(result.url).toBe('https://example.com')
+    expect(result.date).toBeTruthy()
+  })
+
+  it('extracts JSON-LD with nested objects across lines', async () => {
+    const html = `
+      <html><head>
+      <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "Organization",
+        "name": "Jumping Park",
+        "contactPoint": {
+          "@type": "ContactPoint",
+          "telephone": "+1234567890"
+        }
+      }
+      </script>
+      </head></html>
+    `
+
+    mockFetch(async (_input: string | URL | Request, _init?: RequestInit) =>
+      makeHtmlResponse(html),
+    )
+
+    const result = await extractJsonLd('https://example.com')
+
+    expect(result.types).toEqual(['Organization'])
+    expect(result.blocks).toHaveLength(1)
+    expect(result.blocks[0]).toHaveProperty('name', 'Jumping Park')
+  })
+
+  it('returns empty types when no JSON-LD blocks found', async () => {
+    const html = '<html><head></head><body><p>No structured data here</p></body></html>'
+
+    mockFetch(async (_input: string | URL | Request, _init?: RequestInit) =>
+      makeHtmlResponse(html),
+    )
+
+    const result = await extractJsonLd('https://example.com')
+
+    expect(result.types).toEqual([])
+    expect(result.blocks).toEqual([])
+  })
+
+  it('throws on malformed JSON inside a JSON-LD block', async () => {
+    const html = `
+      <html><head>
+      <script type="application/ld+json">this is not valid json {{{</script>
+      </head></html>
+    `
+
+    mockFetch(async (_input: string | URL | Request, _init?: RequestInit) =>
+      makeHtmlResponse(html),
+    )
+
+    await expect(extractJsonLd('https://example.com')).rejects.toThrow()
+  })
+
+  it('throws on network failure', async () => {
+    mockFetch(async (_input: string | URL | Request, _init?: RequestInit) => {
+      throw new Error('ENOTFOUND')
+    })
+
+    await expect(extractJsonLd('https://example.com')).rejects.toThrow(/ENOTFOUND/)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// 1.3 validate-public-crawl.ts
+// ---------------------------------------------------------------------------
+
+describe('validate-public-crawl', () => {
+  let runCrawl: (baseUrl: string) => Promise<{
+    date: string
+    baseUrl: string
+    checks: {
+      robotsTxt: { status: number; adminBlocked: boolean; pass: boolean }
+      sitemap: { status: number; urlCount: number; pass: boolean }
+      llmsTxt: { status: number; hasContent: boolean; pass: boolean }
+      pricingMd: { status: number; hasContent: boolean; pass: boolean }
+    }
+  }>
+
+  beforeAll(async () => {
+    const mod = await import('../scripts/validate-public-crawl')
+    runCrawl = mod.runCrawl
+  })
+
+  it('passes all checks when all public assets are healthy', async () => {
+    let callCount = 0
+    mockFetch(async (_input: string | URL | Request, _init?: RequestInit) => {
+      callCount++
+      const url = typeof _input === 'string' ? _input : (_input as URL).toString()
+      if (url.includes('robots.txt')) {
+        return makeTextResponse(
+          'User-agent: *\nAllow: /\nDisallow: /admin/\nSitemap: https://example.com/sitemap.xml',
+        )
+      }
+      if (url.includes('sitemap.xml')) {
+        return makeXmlResponse(
+          '<?xml version="1.0" encoding="UTF-8"?><urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"><url><loc>https://example.com/</loc></url><url><loc>https://example.com/page</loc></url></urlset>',
+        )
+      }
+      if (url.includes('llms.txt')) {
+        return makeTextResponse('# Jumping Park\n\n## Citation Guidance\n\nGood content here.')
+      }
+      if (url.includes('pricing.md')) {
+        return makeMdResponse('# Pricing — Jumping Park\n\n## Digital consent\n\nClear pricing info.')
+      }
+      return new Response('Not Found', { status: 404 })
+    })
+
+    const result = await runCrawl('https://example.com')
+
+    expect(result.checks.robotsTxt.status).toBe(200)
+    expect(result.checks.robotsTxt.adminBlocked).toBe(true)
+    expect(result.checks.robotsTxt.pass).toBe(true)
+    expect(result.checks.sitemap.status).toBe(200)
+    expect(result.checks.sitemap.urlCount).toBe(2)
+    expect(result.checks.sitemap.pass).toBe(true)
+    expect(result.checks.llmsTxt.status).toBe(200)
+    expect(result.checks.llmsTxt.hasContent).toBe(true)
+    expect(result.checks.llmsTxt.pass).toBe(true)
+    expect(result.checks.pricingMd.status).toBe(200)
+    expect(result.checks.pricingMd.hasContent).toBe(true)
+    expect(result.checks.pricingMd.pass).toBe(true)
+    expect(result.baseUrl).toBe('https://example.com')
+    expect(result.date).toBeTruthy()
+  })
+
+  it('reports missing llms.txt as non-blocking', async () => {
+    let callCount = 0
+    mockFetch(async (_input: string | URL | Request, _init?: RequestInit) => {
+      callCount++
+      const url = typeof _input === 'string' ? _input : (_input as URL).toString()
+      if (url.includes('robots.txt')) {
+        return makeTextResponse(
+          'User-agent: *\nAllow: /\nSitemap: https://example.com/sitemap.xml',
+        )
+      }
+      if (url.includes('sitemap.xml')) {
+        return makeXmlResponse(
+          '<?xml version="1.0"?><urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"><url><loc>https://example.com/</loc></url></urlset>',
+        )
+      }
+      if (url.includes('pricing.md')) {
+        return makeMdResponse('# Pricing\n\nInfo.')
+      }
+      return new Response('Not Found', { status: 404 })
+    })
+
+    const result = await runCrawl('https://example.com')
+
+    expect(result.checks.llmsTxt.status).toBe(404)
+    expect(result.checks.llmsTxt.hasContent).toBe(false)
+    expect(result.checks.llmsTxt.pass).toBe(false)
+  })
+
+  it('reports sitemap failure on malformed XML', async () => {
+    mockFetch(async (_input: string | URL | Request, _init?: RequestInit) => {
+      const url = typeof _input === 'string' ? _input : (_input as URL).toString()
+      if (url.includes('robots.txt')) {
+        return makeTextResponse('User-agent: *\nAllow: /\nSitemap: https://example.com/sitemap.xml')
+      }
+      if (url.includes('sitemap.xml')) {
+        return makeXmlResponse('<not-xml>unclosed', 200)
+      }
+      if (url.includes('llms.txt')) {
+        return makeTextResponse('# OK')
+      }
+      if (url.includes('pricing.md')) {
+        return makeMdResponse('# OK')
+      }
+      return new Response('Not Found', { status: 404 })
+    })
+
+    const result = await runCrawl('https://example.com')
+
+    expect(result.checks.sitemap.status).toBe(200)
+    expect(result.checks.sitemap.pass).toBe(false)
+  })
+
+  it('reports robots.txt failure when admin section is not blocked', async () => {
+    mockFetch(async (_input: string | URL | Request, _init?: RequestInit) => {
+      const url = typeof _input === 'string' ? _input : (_input as URL).toString()
+      if (url.includes('robots.txt')) {
+        return makeTextResponse('User-agent: *\nAllow: /')
+      }
+      if (url.includes('sitemap.xml')) {
+        return makeXmlResponse(
+          '<?xml version="1.0"?><urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"><url><loc>https://example.com/</loc></url></urlset>',
+        )
+      }
+      if (url.includes('llms.txt')) {
+        return makeTextResponse('# OK')
+      }
+      if (url.includes('pricing.md')) {
+        return makeMdResponse('# OK')
+      }
+      return new Response('Not Found', { status: 404 })
+    })
+
+    const result = await runCrawl('https://example.com')
+
+    expect(result.checks.robotsTxt.status).toBe(200)
+    expect(result.checks.robotsTxt.adminBlocked).toBe(false)
+  })
+
+  it('handles network errors gracefully for individual checks', async () => {
+    mockFetch(async (_input: string | URL | Request, _init?: RequestInit) => {
+      const url = typeof _input === 'string' ? _input : (_input as URL).toString()
+      if (url.includes('robots.txt')) {
+        throw new Error('ECONNREFUSED')
+      }
+      if (url.includes('sitemap.xml')) {
+        return makeXmlResponse(
+          '<?xml version="1.0"?><urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"><url><loc>https://example.com/</loc></url></urlset>',
+        )
+      }
+      if (url.includes('llms.txt')) {
+        return makeTextResponse('# OK')
+      }
+      if (url.includes('pricing.md')) {
+        return makeMdResponse('# OK')
+      }
+      return new Response('Not Found', { status: 404 })
+    })
+
+    const result = await runCrawl('https://example.com')
+
+    expect(result.checks.robotsTxt.status).toBe(0)
+    expect(result.checks.robotsTxt.adminBlocked).toBe(false)
+    expect(result.checks.robotsTxt.pass).toBe(false)
+    expect(result.checks.sitemap.pass).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary
- add 3 automation scripts for external validation: PageSpeed Insights API, JSON-LD extraction, public crawl
- populate 7 evidence files with real automated data or honest pending status with instructions
- add `validate:evidence` npm script that chains all 3 validators
- zero fabricated scores — all manual validations marked pending with clear steps

## Changes
- `scripts/validate-pagespeed.ts` — PSI API client, extracts Lighthouse scores
- `scripts/extract-jsonld.ts` — fetches production page, extracts JSON-LD structured data
- `scripts/validate-public-crawl.ts` — validates robots.txt, sitemap, llms.txt, pricing.md
- `tests/evidence-scripts.test.ts` — 14 unit tests with mocked fetch
- `docs/portfolio/evidence/` — 7 evidence files (3 new, 4 updated)
- `package.json` — added `validate:evidence` script

## Testing
- [x] `bun test` (14/14 pass)
- [x] `tsc --noEmit` (clean)
- [x] GGA review passed

## Evidence status
| Type | Status |
|---|---|
| PageSpeed / Lighthouse | automated (needs PSI_API_KEY for full data) |
| JSON-LD extraction | automated |
| Public crawl | automated (4/4 pass) |
| Rich Results Test | pending manual |
| Schema.org Validator | pending manual |
| Google Search Console | pending manual |
| AI visibility | pending manual |
| WCAG/WIG deep review | partial (Axe data included, manual pending) |