### PR TITLE
fix(seo): remove homepage from noindex prefixes to allow search indexing

### DIFF
--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -8,7 +8,6 @@ import { evaluateHardeningFlag, HARDENING_FLAG } from "@/lib/hardeningPolicy";
 
 const PUBLIC_ADMIN_ROUTES = ["/admin/login", "/admin/unauthorized"];
 const NOINDEX_PREFIXES = [
-	"/",
 	"/admin",
 	"/ingreso",
 	"/otp",

--- a/tests/seo-public.test.ts
+++ b/tests/seo-public.test.ts
@@ -31,9 +31,9 @@ async function withEnv<T>(
 }
 
 describe('public seo boundary', () => {
-	it('applies noindex header to kiosk root without leaking to public pages', async () => {
+	it('applies noindex header to kiosk pages without leaking to public pages', async () => {
 		await withEnv('PUBLIC_SEO_ENABLED', 'true', async () => {
-			const kioskResponse = await proxy(new NextRequest('https://example.com/'))
+			const kioskResponse = await proxy(new NextRequest('https://example.com/ingreso'))
 			const publicResponse = await proxy(
 				new NextRequest('https://example.com/consentimiento-digital'),
 			)


### PR DESCRIPTION
## Summary
- remove `/` from `NOINDEX_PREFIXES` in `proxy.ts`
- homepage was getting `X-Robots-Tag: noindex, nofollow` header, blocking all search indexing
- this was the root cause of SEO score 69 on PSI

## Impact
- SEO: 69 → expected 90+ (page is now crawlable)
- Performance: no change
- Security: kiosk flow pages (`/ingreso`, `/otp`, `/registro`, `/consentimiento`, `/exito`) remain noindexed

## Testing
- [x] `bun run check:format` (clean)
- [x] `tsc --noEmit` (clean)
- [x] GGA review passed