### PR TITLE
chore(vercel): disable preview deployments, only deploy main

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "buildCommand": "bun run build",
+  "installCommand": "bun install",
+  "framework": "nextjs",
+  "git": {
+    "deploymentEnabled": {
+      "main": true,
+      "*": false
+    }
+  }
+}


### PR DESCRIPTION
## Changes
- add `vercel.json` to disable preview deployments
- only `main` branch triggers production deployments
- no more preview URLs per PR (reduces deployment clutter from 262+ to just production)

## Impact
- Future PRs will NOT get Vercel preview URLs
- Only merges to `main` will deploy to production
- Old deployments must be cleaned manually from Vercel dashboard