### PR TITLE
feat(i18n): add full Spanish/English support to consentimiento-digital page

### DIFF
--- a/src/app/(public)/consentimiento-digital/page.tsx
+++ b/src/app/(public)/consentimiento-digital/page.tsx
@@ -18,10 +18,15 @@ import type { Metadata } from "next";
 import Image from "next/image";
 import Link from "next/link";
 import Script from "next/script";
+import { LanguageToggle } from "@/components/kiosk/LanguageToggle";
 import { AnimatedSection } from "@/components/public/AnimatedSection";
 import cosmicStyles from "@/components/public/cosmic-bg.module.css";
+import { LanguageProvider } from "@/contexts/LanguageContext";
 import { buildConsentimientoDigitalMetadata } from "@/lib/consentimientoDigitalSeo";
+import { type DictionaryKey } from "@/lib/i18n/dictionary";
+import { createServerTranslator } from "@/lib/i18n/serverTranslate";
 import { PAGE_IMAGE_VARIANTS } from "@/lib/imageOptimization";
+import { cn } from "@/lib/utils";
 import {
 	APP_NAME,
 	BUSINESS_PHONE,
@@ -36,109 +41,17 @@ import {
 } from "@/lib/seo";
 
 // ---------------------------------------------------------------------------
-// Local display constants (UI copy in Spanish)
+// Social display names for UI
 // ---------------------------------------------------------------------------
 
-const PARK_TAGLINE = "Primavera Urbana";
-const PARK_COUNTRY = "Colombia";
-const PARK_CITY_REGION = "Villavicencio, Meta";
-
-const PARK_STATS = {
-	trampolines: "50+",
-	visitors: "10,000+",
-	rating: "4.8",
-} as const;
-
-const PARK_ATTRACTIONS = [
-	"Mas de 50 camas elasticas interconectadas",
-	"Piscina de espuma gigante",
-	"Zona de salto libre",
-	"Area infantil exclusiva",
-	"Cancha de dodgeball",
-	"Muro de escalada",
-] as const;
-
-const PARK_HOURS_DISPLAY = {
-	weekdays: "Lunes a Viernes: 1:30 PM - 8:00 PM",
-	weekends: "Sabados, Domingos y Festivos: 11:00 AM - 8:00 PM",
-} as const;
-
-// Social display names for UI
 const INSTAGRAM_URL = BUSINESS_SOCIAL_PROFILES[0];
 const FACEBOOK_URL = BUSINESS_SOCIAL_PROFILES[1];
 
 const WHATSAPP_NUMBER_RAW = BUSINESS_PHONE.replace(/[\s+]/g, "");
 const WHATSAPP_URL = `https://wa.me/${WHATSAPP_NUMBER_RAW}`;
 
-const PROCESS_STEPS = [
-	{
-		step: 1,
-		title: "Completa tus datos",
-		description:
-			"Ingresa tu informacion personal y la de los menores que te acompanan. El formulario guiado te lleva paso a paso.",
-		icon: FileCheck,
-		duration: "2 min",
-	},
-	{
-		step: 2,
-		title: "Verifica tu identidad",
-		description:
-			"Recibe un codigo de 6 digitos en tu correo electronico. Esta validacion protege tu informacion y confirma tu identidad.",
-		icon: ShieldCheck,
-		duration: "1 min",
-	},
-	{
-		step: 3,
-		title: "Firma el consentimiento",
-		description:
-			"Revisa los terminos y firma digitalmente. Tu consentimiento queda registrado y listo para cuando llegues al parque.",
-		icon: PenTool,
-		duration: "1 min",
-	},
-] as const;
-
-const BENEFITS = [
-	{
-		title: "Ahorra tiempo en la entrada",
-		description:
-			"Llega al parque con el consentimiento firmado y pasa directo a la diversion. Sin filas, sin esperas, sin papeles.",
-		icon: Zap,
-	},
-	{
-		title: "Registra a toda tu familia",
-		description:
-			"Un solo adulto puede registrar a todos los menores del grupo. Cada menor queda vinculado a su responsable legal.",
-		icon: Users,
-	},
-	{
-		title: "Seguridad garantizada",
-		description:
-			"Validacion por codigo OTP, firma digital con valor legal, y datos protegidos. Todo cumple con la normativa colombiana.",
-		icon: ShieldCheck,
-	},
-] as const;
-
-const REQUIREMENTS = [
-	{
-		item: "Documento de identidad",
-		detail: "Cedula de ciudadania o tarjeta de identidad",
-	},
-	{
-		item: "Correo electronico activo",
-		detail: "Para recibir el codigo de verificacion OTP",
-	},
-	{
-		item: "Datos de menores",
-		detail: "Documento y fecha de nacimiento de cada menor",
-	},
-	{
-		item: "5 minutos de tu tiempo",
-		detail: "Es todo lo que necesitas para completar el proceso",
-	},
-] as const;
-
 // ---------------------------------------------------------------------------
-// Structured data
+// Structured data (not translatable — kept as-is)
 // ---------------------------------------------------------------------------
 
 const structuredData = buildPublicPageStructuredData({
@@ -152,12 +65,88 @@ const faqSchema = buildFaqPageSchema(CONSENTIMIENTO_DIGITAL_FAQ_ENTRIES);
 export const metadata: Metadata = buildConsentimientoDigitalMetadata();
 
 // ---------------------------------------------------------------------------
-// Page component (Server Component)
+// Page component (async Server Component)
 // ---------------------------------------------------------------------------
 
-export default function ConsentimientoDigitalPage() {
+export default async function ConsentimientoDigitalPage() {
+	const { t, locale } = await createServerTranslator();
+
+	// Shorthand helper — t() accepts DictionaryKey, our dynamic keys are valid
+	const tk = (key: DictionaryKey) => t(key);
+
+	// Stats — raw numbers, labels from dictionary
+	const PARK_STATS = {
+		trampolines: "50+",
+		visitors: "10,000+",
+		rating: "4.8",
+	} as const;
+
+	// Process steps — icons are component references, text from dictionary
+	const PROCESS_STEPS = [
+		{
+			step: 1,
+			title: tk("consentDigital.process.step1.title"),
+			description: tk("consentDigital.process.step1.description"),
+			icon: FileCheck,
+			duration: tk("consentDigital.process.step1.duration"),
+		},
+		{
+			step: 2,
+			title: tk("consentDigital.process.step2.title"),
+			description: tk("consentDigital.process.step2.description"),
+			icon: ShieldCheck,
+			duration: tk("consentDigital.process.step2.duration"),
+		},
+		{
+			step: 3,
+			title: tk("consentDigital.process.step3.title"),
+			description: tk("consentDigital.process.step3.description"),
+			icon: PenTool,
+			duration: tk("consentDigital.process.step3.duration"),
+		},
+	] as const;
+
+	// Benefits
+	const BENEFITS = [
+		{
+			title: tk("consentDigital.benefits.item1.title"),
+			description: tk("consentDigital.benefits.item1.description"),
+			icon: Zap,
+		},
+		{
+			title: tk("consentDigital.benefits.item2.title"),
+			description: tk("consentDigital.benefits.item2.description"),
+			icon: Users,
+		},
+		{
+			title: tk("consentDigital.benefits.item3.title"),
+			description: tk("consentDigital.benefits.item3.description"),
+			icon: ShieldCheck,
+		},
+	] as const;
+
+	// Requirements
+	const REQUIREMENTS = [
+		{
+			item: tk("consentDigital.requirements.item1"),
+			detail: tk("consentDigital.requirements.detail1"),
+		},
+		{
+			item: tk("consentDigital.requirements.item2"),
+			detail: tk("consentDigital.requirements.detail2"),
+		},
+		{
+			item: tk("consentDigital.requirements.item3"),
+			detail: tk("consentDigital.requirements.detail3"),
+		},
+		{
+			item: tk("consentDigital.requirements.item4"),
+			detail: tk("consentDigital.requirements.detail4"),
+		},
+	] as const;
+
 	return (
-		<>
+		<LanguageProvider initialLanguage={locale}>
 			<Script
 				id="structured-data"
 				type="application/ld+json"
@@ -179,7 +168,9 @@ export default function ConsentimientoDigitalPage() {
 					<Link href="/" className="flex items-center gap-3">
 						<Image
 							src={PAGE_IMAGE_VARIANTS.publicConsentLogo.src}
-							alt={`Logo de ${APP_NAME}`}
+							alt={t("consentDigital.header.logoAlt", {
+								appName: APP_NAME,
+							})}
 							width={140}
 							height={40}
 							priority
@@ -192,19 +183,20 @@ export default function ConsentimientoDigitalPage() {
 							href="#como-funciona"
 							className="hidden text-sm font-medium text-zinc-400 transition-colors hover:text-white sm:block"
 						>
-							Como funciona
+							{t("consentDigital.header.navProcess")}
 						</Link>
 						<Link
 							href="#preguntas"
 							className="hidden text-sm font-medium text-zinc-400 transition-colors hover:text-white sm:block"
 						>
-							Preguntas
+							{t("consentDigital.header.navFaq")}
 						</Link>
+						<LanguageToggle variant="minimal" />
 						<Link
 							href="/"
 							className="inline-flex items-center gap-2 rounded-full bg-brand-green px-4 py-2 text-sm font-bold text-slate-950 transition-all hover:brightness-110"
 						>
-							Iniciar registro
+							{t("consentDigital.header.ctaButton")}
 							<ArrowRight className="h-4 w-4" aria-hidden="true" />
 						</Link>
 					</nav>
@@ -213,7 +205,7 @@ export default function ConsentimientoDigitalPage() {
 
 			<main
 				id="main-content"
-				className={`${cosmicStyles.background} min-h-screen pt-16`}
+				className={cn(cosmicStyles.background, "min-h-screen pt-16")}
 			>
 				{/* ============================================================
 				    HERO SECTION
@@ -230,20 +222,22 @@ export default function ConsentimientoDigitalPage() {
 											aria-hidden="true"
 										/>
 										<span className="text-sm font-medium text-brand-green">
-											{PARK_STATS.rating} estrellas en Google
+											{PARK_STATS.rating}{" "}
+											{t("consentDigital.stats.ratingLabel")}
 										</span>
 									</div>
 
 									<h1 className="text-balance text-4xl font-black tracking-tight text-white sm:text-5xl lg:text-6xl">
-										Firma tu consentimiento{" "}
-										<span className="text-brand-green">antes de llegar</span>
+										{t("consentDigital.hero.title1")}{" "}
+										<span className="text-brand-green">
+											{t("consentDigital.hero.title2")}
+										</span>
 									</h1>
 
 									<p className="max-w-xl text-pretty text-lg leading-relaxed text-zinc-300">
-										Completa el registro digital de{" "}
-										<strong className="text-white">{APP_NAME}</strong> desde tu
-										casa. Valida tu identidad con un codigo OTP, firma
-										digitalmente y llega al parque listo para saltar.
+										{t("consentDigital.hero.subtitle", {
+											appName: APP_NAME,
+										})}
 									</p>
 
 									<div className="flex flex-col gap-4 pt-2 sm:flex-row">
@@ -251,23 +245,23 @@ export default function ConsentimientoDigitalPage() {
 											href="/"
 											className="inline-flex items-center justify-center gap-2 rounded-full bg-brand-green px-8 py-4 text-lg font-bold text-slate-950 shadow-lg shadow-brand-green/25 transition-all hover:brightness-110 hover:shadow-xl focus:outline-none focus:ring-2 focus:ring-brand-green focus:ring-offset-2 focus:ring-offset-slate-950"
 										>
-											Empezar registro
+											{t("consentDigital.hero.ctaPrimary")}
 											<ChevronRight className="h-5 w-5" aria-hidden="true" />
 										</Link>
 										<Link
 											href="#como-funciona"
 											className="inline-flex items-center justify-center gap-2 rounded-full border border-white/20 bg-white/5 px-6 py-4 font-semibold text-white transition-all hover:border-white/40 hover:bg-white/10"
 										>
-											Ver como funciona
+											{t("consentDigital.hero.ctaSecondary")}
 										</Link>
 										<a
 											href={WHATSAPP_URL}
 											target="_blank"
 											rel="noopener noreferrer"
-											aria-label="Escribinos por WhatsApp (abre en nueva pestaña)"
+											aria-label={t("consentDigital.hero.ctaWhatsAppAria")}
 											className="inline-flex items-center justify-center gap-2 rounded-full border border-brand-green/30 bg-brand-green/10 px-6 py-4 font-semibold text-brand-green transition-all hover:border-brand-green/50 hover:bg-brand-green/20"
 										>
-											Escribinos por WhatsApp
+											{t("consentDigital.hero.ctaWhatsApp")}
 										</a>
 									</div>
 
@@ -285,7 +279,7 @@ export default function ConsentimientoDigitalPage() {
 													{PARK_STATS.visitors}
 												</p>
 												<p className="text-xs text-zinc-400">
-													visitantes felices
+													{t("consentDigital.stats.visitorsLabel")}
 												</p>
 											</div>
 										</div>
@@ -300,7 +294,9 @@ export default function ConsentimientoDigitalPage() {
 												<p className="text-lg font-bold text-white">
 													{PARK_STATS.trampolines}
 												</p>
-												<p className="text-xs text-zinc-400">trampolines</p>
+												<p className="text-xs text-zinc-400">
+													{t("consentDigital.stats.trampolinesLabel")}
+												</p>
 											</div>
 										</div>
 									</div>
@@ -312,7 +308,9 @@ export default function ConsentimientoDigitalPage() {
 									<div className="relative overflow-hidden rounded-3xl border border-white/10 bg-slate-900/50 p-8">
 										<Image
 											src={PAGE_IMAGE_VARIANTS.kioskAstronaut.src}
-											alt="Astronauta de Jumping Park invitandote a registrarte"
+											alt={t("consentDigital.hero.imageAlt", {
+												appName: APP_NAME,
+											})}
 											width={400}
 											height={400}
 											priority
@@ -322,10 +320,11 @@ export default function ConsentimientoDigitalPage() {
 										<div className="mt-6 rounded-2xl border border-white/10 bg-white/5 p-4 backdrop-blur">
 											<p className="text-center text-sm text-zinc-300">
 												<strong className="text-white">
-													Mas de {PARK_STATS.trampolines} camas elasticas
+													{t("consentDigital.hero.imageCaption1", {
+														count: PARK_STATS.trampolines,
+													})}
 												</strong>{" "}
-												te esperan en el parque de trampolines mas grande de
-												Villavicencio.
+												{t("consentDigital.hero.imageCaption2")}
 											</p>
 										</div>
 									</div>
@@ -350,11 +349,10 @@ export default function ConsentimientoDigitalPage() {
 									id="process-title"
 									className="text-balance text-3xl font-black tracking-tight text-white sm:text-4xl"
 								>
-									Tres pasos simples para tu consentimiento digital
+									{t("consentDigital.process.title")}
 								</h2>
 								<p className="mt-4 text-lg text-zinc-400">
-									El proceso completo toma menos de 5 minutos. Hazlo desde tu
-									celular o computador.
+									{t("consentDigital.process.subtitle")}
 								</p>
 							</div>
 
@@ -393,7 +391,7 @@ export default function ConsentimientoDigitalPage() {
 							{/* Requirements Box */}
 							<div className="mt-12 rounded-2xl border border-brand-yellow/20 bg-brand-yellow/5 p-6 sm:p-8">
 								<h3 className="mb-4 text-lg font-bold text-white">
-									Que necesitas tener listo
+									{t("consentDigital.process.requirementsTitle")}
 								</h3>
 								<div className="grid gap-4 sm:grid-cols-2">
 									{REQUIREMENTS.map((req) => (
@@ -428,11 +426,10 @@ export default function ConsentimientoDigitalPage() {
 									id="benefits-title"
 									className="text-balance text-3xl font-black tracking-tight text-white sm:text-4xl"
 								>
-									Por que usar el consentimiento digital
+									{t("consentDigital.benefits.title")}
 								</h2>
 								<p className="mx-auto mt-4 max-w-2xl text-lg text-zinc-400">
-									Disenado para familias que quieren aprovechar al maximo su
-									tiempo en el parque.
+									{t("consentDigital.benefits.subtitle")}
 								</p>
 							</div>
 
@@ -476,10 +473,10 @@ export default function ConsentimientoDigitalPage() {
 									id="faq-title"
 									className="text-balance text-3xl font-black tracking-tight text-white sm:text-4xl"
 								>
-									Preguntas frecuentes
+									{t("consentDigital.faq.title")}
 								</h2>
 								<p className="mt-4 text-lg text-zinc-400">
-									Resuelve tus dudas antes de completar el registro.
+									{t("consentDigital.faq.subtitle")}
 								</p>
 							</div>
 
@@ -521,20 +518,25 @@ export default function ConsentimientoDigitalPage() {
 										id="about-title"
 										className="text-balance text-3xl font-black tracking-tight text-white sm:text-4xl"
 									>
-										Conoce {APP_NAME}
+										{t("consentDigital.about.title", { appName: APP_NAME })}
 									</h2>
 									<p className="mt-4 text-lg text-zinc-400">
-										El parque de trampolines mas grande de Villavicencio,
-										ubicado en Centro Comercial Primavera Urbana. Diversion
-										garantizada para toda la familia.
+										{t("consentDigital.about.description")}
 									</p>
 
 									<div className="mt-8 space-y-3">
 										<h3 className="text-sm font-bold uppercase tracking-wider text-zinc-500">
-											Nuestras atracciones
+											{t("consentDigital.attractions.title")}
 										</h3>
 										<ul className="grid gap-2 sm:grid-cols-2">
-											{PARK_ATTRACTIONS.map((attraction) => (
+											{[
+												t("consentDigital.attractions.item1"),
+												t("consentDigital.attractions.item2"),
+												t("consentDigital.attractions.item3"),
+												t("consentDigital.attractions.item4"),
+												t("consentDigital.attractions.item5"),
+												t("consentDigital.attractions.item6"),
+											].map((attraction) => (
 												<li
 													key={attraction}
 													className="flex items-center gap-2 text-zinc-300"
@@ -553,7 +555,7 @@ export default function ConsentimientoDigitalPage() {
 								{/* Contact Card */}
 								<div className="rounded-2xl border border-white/10 bg-white/[0.03] p-6 sm:p-8">
 									<h3 className="mb-6 text-xl font-bold text-white">
-										Informacion de contacto
+										{t("consentDigital.contact.title")}
 									</h3>
 
 									<div className="space-y-4">
@@ -566,13 +568,14 @@ export default function ConsentimientoDigitalPage() {
 											</div>
 											<div>
 												<p className="font-medium text-white">
-													Centro Comercial Primavera Urbana
+													{t("consentDigital.mallName")}
 												</p>
 												<p className="text-sm text-zinc-400">
 													{BUSINESS_STREET_ADDRESS}
 												</p>
 												<p className="text-sm text-zinc-400">
-													{PARK_CITY_REGION}, {PARK_COUNTRY}
+													{t("consentDigital.cityRegion")},{" "}
+													{t("consentDigital.country")}
 												</p>
 											</div>
 										</div>
@@ -591,7 +594,9 @@ export default function ConsentimientoDigitalPage() {
 												>
 													{BUSINESS_PHONE}
 												</a>
-												<p className="text-sm text-zinc-400">Llamanos</p>
+												<p className="text-sm text-zinc-400">
+													{t("consentDigital.contact.callUs")}
+												</p>
 											</div>
 										</div>
 
@@ -604,10 +609,10 @@ export default function ConsentimientoDigitalPage() {
 											</div>
 											<div>
 												<p className="text-sm text-zinc-300">
-													{PARK_HOURS_DISPLAY.weekdays}
+													{t("consentDigital.hours.weekdays")}
 												</p>
 												<p className="text-sm text-zinc-300">
-													{PARK_HOURS_DISPLAY.weekends}
+													{t("consentDigital.hours.weekends")}
 												</p>
 											</div>
 										</div>
@@ -618,7 +623,9 @@ export default function ConsentimientoDigitalPage() {
 												target="_blank"
 												rel="noopener noreferrer"
 												className="flex items-center gap-2 rounded-lg border border-white/10 bg-white/5 px-4 py-2 text-sm text-zinc-300 transition-colors hover:border-pink-500/30 hover:bg-pink-500/10 hover:text-pink-400"
-												aria-label="Seguir en Instagram (abre en nueva pestaña)"
+												aria-label={t(
+													"consentDigital.contact.followInstagramAria",
+												)}
 											>
 												<Instagram className="h-4 w-4" aria-hidden="true" />
 												Instagram
@@ -628,7 +635,9 @@ export default function ConsentimientoDigitalPage() {
 												target="_blank"
 												rel="noopener noreferrer"
 												className="flex items-center gap-2 rounded-lg border border-white/10 bg-white/5 px-4 py-2 text-sm text-zinc-300 transition-colors hover:border-blue-500/30 hover:bg-blue-500/10 hover:text-blue-400"
-												aria-label="Seguir en Facebook (abre en nueva pestaña)"
+												aria-label={t(
+													"consentDigital.contact.followFacebookAria",
+												)}
 											>
 												<Facebook className="h-4 w-4" aria-hidden="true" />
 												Facebook
@@ -648,32 +657,31 @@ export default function ConsentimientoDigitalPage() {
 					<section className="border-t border-white/10 px-4 py-16 sm:px-6 sm:py-24">
 						<div className="mx-auto max-w-4xl text-center">
 							<h2 className="text-balance text-3xl font-black tracking-tight text-white sm:text-4xl">
-								No pierdas mas tiempo en filas
+								{t("consentDigital.ctaFinal.title")}
 							</h2>
 							<p className="mx-auto mt-4 max-w-2xl text-lg text-zinc-400">
-								Completa tu consentimiento digital ahora y llega al parque listo
-								para la diversion. Tu familia te lo agradecera.
+								{t("consentDigital.ctaFinal.subtitle")}
 							</p>
 							<div className="mt-8 flex flex-col items-center justify-center gap-4 sm:flex-row">
 								<Link
 									href="/"
 									className="inline-flex items-center justify-center gap-2 rounded-full bg-brand-green px-10 py-4 text-lg font-bold text-slate-950 shadow-lg shadow-brand-green/25 transition-all hover:brightness-110 hover:shadow-xl focus:outline-none focus:ring-2 focus:ring-brand-green focus:ring-offset-2 focus:ring-offset-slate-950"
 								>
-									Completar registro ahora
+									{t("consentDigital.ctaFinal.buttonPrimary")}
 									<ArrowRight className="h-5 w-5" aria-hidden="true" />
 								</Link>
 								<a
 									href={WHATSAPP_URL}
 									target="_blank"
 									rel="noopener noreferrer"
-									aria-label="Consultar por WhatsApp (abre en nueva pestaña)"
+									aria-label={t("consentDigital.ctaFinal.buttonWhatsAppAria")}
 									className="inline-flex items-center justify-center gap-2 rounded-full border border-brand-green/30 bg-brand-green/10 px-10 py-4 text-lg font-bold text-brand-green transition-all hover:border-brand-green/50 hover:bg-brand-green/20"
 								>
-									Consultar por WhatsApp
+									{t("consentDigital.ctaFinal.buttonWhatsApp")}
 								</a>
 							</div>
 							<p className="mt-6 text-sm text-zinc-500">
-								El proceso toma menos de 5 minutos
+								{t("consentDigital.ctaFinal.timeNote")}
 							</p>
 						</div>
 					</section>
@@ -690,23 +698,25 @@ export default function ConsentimientoDigitalPage() {
 						<div className="sm:col-span-2 lg:col-span-1">
 							<Image
 								src={PAGE_IMAGE_VARIANTS.publicConsentLogo.src}
-								alt={`Logo de ${APP_NAME}`}
+								alt={t("consentDigital.footer.logoAlt", { appName: APP_NAME })}
 								width={140}
 								height={40}
 								loading="lazy"
 								sizes={PAGE_IMAGE_VARIANTS.publicConsentLogo.sizes}
 								className="h-10 w-auto"
 							/>
-							<p className="mt-4 text-sm text-zinc-500">{PARK_TAGLINE}</p>
+							<p className="mt-4 text-sm text-zinc-500">
+								{t("consentDigital.tagline")}
+							</p>
 							<p className="mt-2 text-sm text-zinc-500">
-								El parque de trampolines mas grande de Villavicencio.
+								{t("consentDigital.footer.tagline")}
 							</p>
 						</div>
 
 						{/* Links */}
 						<div>
 							<h4 className="mb-4 text-sm font-bold uppercase tracking-wider text-zinc-400">
-								Enlaces rapidos
+								{t("consentDigital.footer.quickLinks")}
 							</h4>
 							<ul className="space-y-2">
 								<li>
@@ -714,7 +724,7 @@ export default function ConsentimientoDigitalPage() {
 										href="/"
 										className="text-sm text-zinc-500 hover:text-white"
 									>
-										Iniciar registro
+										{t("consentDigital.footer.linkStartRegistration")}
 									</Link>
 								</li>
 								<li>
@@ -722,7 +732,7 @@ export default function ConsentimientoDigitalPage() {
 										href="#como-funciona"
 										className="text-sm text-zinc-500 hover:text-white"
 									>
-										Como funciona
+										{t("consentDigital.footer.linkHowItWorks")}
 									</Link>
 								</li>
 								<li>
@@ -730,7 +740,7 @@ export default function ConsentimientoDigitalPage() {
 										href="#preguntas"
 										className="text-sm text-zinc-500 hover:text-white"
 									>
-										Preguntas frecuentes
+										{t("consentDigital.footer.linkFaq")}
 									</Link>
 								</li>
 							</ul>
@@ -739,7 +749,7 @@ export default function ConsentimientoDigitalPage() {
 						{/* Contact */}
 						<div>
 							<h4 className="mb-4 text-sm font-bold uppercase tracking-wider text-zinc-400">
-								Contacto
+								{t("consentDigital.footer.contact")}
 							</h4>
 							<ul className="space-y-2">
 								<li className="flex items-center gap-2 text-sm text-zinc-500">
@@ -757,7 +767,7 @@ export default function ConsentimientoDigitalPage() {
 						{/* Social */}
 						<div>
 							<h4 className="mb-4 text-sm font-bold uppercase tracking-wider text-zinc-400">
-								Siguenos
+								{t("consentDigital.footer.followUs")}
 							</h4>
 							<div className="flex gap-3">
 								<a
@@ -765,7 +775,7 @@ export default function ConsentimientoDigitalPage() {
 									target="_blank"
 									rel="noopener noreferrer"
 									className="flex h-10 w-10 items-center justify-center rounded-lg border border-white/10 bg-white/5 text-zinc-400 transition-colors hover:border-pink-500/30 hover:bg-pink-500/10 hover:text-pink-400"
-									aria-label="Instagram (abre en nueva pestaña)"
+									aria-label={t("consentDigital.footer.instagramAria")}
 								>
 									<Instagram className="h-5 w-5" aria-hidden="true" />
 								</a>
@@ -774,7 +784,7 @@ export default function ConsentimientoDigitalPage() {
 									target="_blank"
 									rel="noopener noreferrer"
 									className="flex h-10 w-10 items-center justify-center rounded-lg border border-white/10 bg-white/5 text-zinc-400 transition-colors hover:border-blue-500/30 hover:bg-blue-500/10 hover:text-blue-400"
-									aria-label="Facebook (abre en nueva pestaña)"
+									aria-label={t("consentDigital.footer.facebookAria")}
 								>
 									<Facebook className="h-5 w-5" aria-hidden="true" />
 								</a>
@@ -786,12 +796,14 @@ export default function ConsentimientoDigitalPage() {
 					<div className="mt-12 flex flex-col items-center justify-between gap-4 border-t border-white/10 pt-8 sm:flex-row">
 						<p className="text-sm text-zinc-500">{BUSINESS_STREET_ADDRESS}</p>
 						<p className="text-sm text-zinc-600">
-							&copy; {new Date().getFullYear()} {APP_NAME}. Todos los derechos
-							reservados.
+							{t("consentDigital.footer.copyright", {
+								year: new Date().getFullYear(),
+								appName: APP_NAME,
+							})}
 						</p>
 					</div>
 				</div>
 			</footer>
-		</>
+		</LanguageProvider>
 	);
 }

--- a/src/components/kiosk/HomepageShell.tsx
+++ b/src/components/kiosk/HomepageShell.tsx
@@ -6,8 +6,10 @@ import { LanguageToggle } from "@/components/kiosk/LanguageToggle";
 import { SecretAdminTrigger } from "@/components/ui/SecretAdminTrigger";
 import type { DictionaryKey, Language } from "@/lib/i18n/dictionary";
 import { PAGE_IMAGE_VARIANTS } from "@/lib/imageOptimization";
+import { BUSINESS_PHONE } from "@/lib/seo";
 
 const INSTAGRAM_URL = "https://www.instagram.com/jumpingparkvillavo/";
+const WHATSAPP_URL = `https://wa.me/${BUSINESS_PHONE.replace(/[\s+]/g, "")}`;
 
 interface HomepageShellProps {
 	t: (
@@ -34,7 +36,7 @@ export function HomepageShell({ t, locale: _locale }: HomepageShellProps) {
 	return (
 		<main
 			id="main-content"
-			className="relative min-h-screen w-full overflow-hidden bg-background text-foreground"
+			className="relative min-h-screen w-full overflow-x-hidden bg-background text-foreground"
 		>
 			{/* Client island — SpaceBackground, images, CTA, bounce indicator */}
 			<HomepageHeroIsland
@@ -133,8 +135,15 @@ export function HomepageShell({ t, locale: _locale }: HomepageShellProps) {
 							<p className="text-sm leading-6">{t("home.business.address")}</p>
 						</div>
 						<div className="flex flex-col items-center gap-3 text-center text-white/70">
-							<Phone className="h-6 w-6 text-primary" />
-							<p className="text-sm">{t("home.business.phone")}</p>
+							<Phone className="h-6 w-6 text-[#25D366]" />
+							<a
+								href={WHATSAPP_URL}
+								target="_blank"
+								rel="noopener noreferrer"
+								className="text-sm font-medium text-[#25D366] hover:text-[#20BD5A] transition-colors"
+							>
+								{t("home.business.phone")}
+							</a>
 							<Link
 								href={INSTAGRAM_URL}
 								target="_blank"

--- a/src/lib/i18n/dictionary.ts
+++ b/src/lib/i18n/dictionary.ts
@@ -1008,6 +1008,402 @@ export const dictionary = {
 		es: "Área de firma digital",
 		en: "Digital signature area",
 	},
+
+	// ============================================================================
+	// PÁGINA CONSENTIMIENTO-DIGITAL (LANDING PÚBLICA)
+	// ============================================================================
+
+	// --- Tagline / Ubicación ---
+	"consentDigital.tagline": {
+		es: "Primavera Urbana",
+		en: "Primavera Urbana",
+	},
+	"consentDigital.country": {
+		es: "Colombia",
+		en: "Colombia",
+	},
+	"consentDigital.cityRegion": {
+		es: "Villavicencio, Meta",
+		en: "Villavicencio, Meta",
+	},
+	"consentDigital.mallName": {
+		es: "Centro Comercial Primavera Urbana",
+		en: "Primavera Urbana Shopping Center",
+	},
+
+	// --- Stats ---
+	"consentDigital.stats.ratingLabel": {
+		es: "estrellas en Google",
+		en: "stars on Google",
+	},
+	"consentDigital.stats.visitorsLabel": {
+		es: "visitantes felices",
+		en: "happy visitors",
+	},
+	"consentDigital.stats.trampolinesLabel": {
+		es: "trampolines",
+		en: "trampolines",
+	},
+
+	// --- Attractions ---
+	"consentDigital.attractions.title": {
+		es: "Nuestras atracciones",
+		en: "Our attractions",
+	},
+	"consentDigital.attractions.item1": {
+		es: "Más de 50 camas elásticas interconectadas",
+		en: "Over 50 interconnected trampolines",
+	},
+	"consentDigital.attractions.item2": {
+		es: "Piscina de espuma gigante",
+		en: "Giant foam pit",
+	},
+	"consentDigital.attractions.item3": {
+		es: "Zona de salto libre",
+		en: "Free jump zone",
+	},
+	"consentDigital.attractions.item4": {
+		es: "Área infantil exclusiva",
+		en: "Exclusive kids area",
+	},
+	"consentDigital.attractions.item5": {
+		es: "Cancha de dodgeball",
+		en: "Dodgeball court",
+	},
+	"consentDigital.attractions.item6": {
+		es: "Muro de escalada",
+		en: "Climbing wall",
+	},
+
+	// --- Hours ---
+	"consentDigital.hours.weekdays": {
+		es: "Lunes a Viernes: 1:30 PM - 8:00 PM",
+		en: "Monday to Friday: 1:30 PM - 8:00 PM",
+	},
+	"consentDigital.hours.weekends": {
+		es: "Sábados, Domingos y Festivos: 11:00 AM - 8:00 PM",
+		en: "Saturdays, Sundays and Holidays: 11:00 AM - 8:00 PM",
+	},
+
+	// --- Header ---
+	"consentDigital.header.logoAlt": {
+		es: "Logo de {appName}",
+		en: "{appName} Logo",
+	},
+	"consentDigital.header.navProcess": {
+		es: "Cómo funciona",
+		en: "How it works",
+	},
+	"consentDigital.header.navFaq": {
+		es: "Preguntas",
+		en: "FAQ",
+	},
+	"consentDigital.header.ctaButton": {
+		es: "Iniciar registro",
+		en: "Start registration",
+	},
+
+	// --- Hero ---
+	"consentDigital.hero.title1": {
+		es: "Firma tu consentimiento",
+		en: "Sign your consent",
+	},
+	"consentDigital.hero.title2": {
+		es: "antes de llegar",
+		en: "before arriving",
+	},
+	"consentDigital.hero.subtitle": {
+		es: "Completa el registro digital de {appName} desde tu casa. Valida tu identidad con un código OTP, firma digitalmente y llega al parque listo para saltar.",
+		en: "Complete the digital registration of {appName} from home. Verify your identity with an OTP code, sign digitally and arrive at the park ready to jump.",
+	},
+	"consentDigital.hero.ctaPrimary": {
+		es: "Empezar registro",
+		en: "Start registration",
+	},
+	"consentDigital.hero.ctaSecondary": {
+		es: "Ver cómo funciona",
+		en: "See how it works",
+	},
+	"consentDigital.hero.ctaWhatsApp": {
+		es: "Escribinos por WhatsApp",
+		en: "Chat with us on WhatsApp",
+	},
+	"consentDigital.hero.ctaWhatsAppAria": {
+		es: "Escribinos por WhatsApp (abre en nueva pestaña)",
+		en: "Chat with us on WhatsApp (opens in new tab)",
+	},
+	"consentDigital.hero.imageAlt": {
+		es: "Astronauta de {appName} invitándote a registrarte",
+		en: "{appName} astronaut inviting you to register",
+	},
+	"consentDigital.hero.imageCaption1": {
+		es: "Más de {count} camas elásticas",
+		en: "Over {count} trampolines",
+	},
+	"consentDigital.hero.imageCaption2": {
+		es: "te esperan en el parque de trampolines más grande de Villavicencio.",
+		en: "await you at the largest trampoline park in Villavicencio.",
+	},
+
+	// --- Process ---
+	"consentDigital.process.title": {
+		es: "Tres pasos simples para tu consentimiento digital",
+		en: "Three simple steps for your digital consent",
+	},
+	"consentDigital.process.subtitle": {
+		es: "El proceso completo toma menos de 5 minutos. Hazlo desde tu celular o computador.",
+		en: "The entire process takes less than 5 minutes. Do it from your phone or computer.",
+	},
+	"consentDigital.process.step1.title": {
+		es: "Completa tus datos",
+		en: "Fill in your details",
+	},
+	"consentDigital.process.step1.description": {
+		es: "Ingresa tu información personal y la de los menores que te acompañan. El formulario guiado te lleva paso a paso.",
+		en: "Enter your personal information and that of the minors accompanying you. The guided form takes you step by step.",
+	},
+	"consentDigital.process.step1.duration": {
+		es: "2 min",
+		en: "2 min",
+	},
+	"consentDigital.process.step2.title": {
+		es: "Verifica tu identidad",
+		en: "Verify your identity",
+	},
+	"consentDigital.process.step2.description": {
+		es: "Recibe un código de 6 dígitos en tu correo electrónico. Esta validación protege tu información y confirma tu identidad.",
+		en: "Receive a 6-digit code in your email. This validation protects your information and confirms your identity.",
+	},
+	"consentDigital.process.step2.duration": {
+		es: "1 min",
+		en: "1 min",
+	},
+	"consentDigital.process.step3.title": {
+		es: "Firma el consentimiento",
+		en: "Sign the consent",
+	},
+	"consentDigital.process.step3.description": {
+		es: "Revisa los términos y firma digitalmente. Tu consentimiento queda registrado y listo para cuando llegues al parque.",
+		en: "Review the terms and sign digitally. Your consent is recorded and ready for when you arrive at the park.",
+	},
+	"consentDigital.process.step3.duration": {
+		es: "1 min",
+		en: "1 min",
+	},
+	"consentDigital.process.requirementsTitle": {
+		es: "Qué necesitas tener listo",
+		en: "What you need to have ready",
+	},
+
+	// --- Requirements ---
+	"consentDigital.requirements.item1": {
+		es: "Documento de identidad",
+		en: "ID document",
+	},
+	"consentDigital.requirements.detail1": {
+		es: "Cédula de ciudadanía o tarjeta de identidad",
+		en: "Citizenship ID or identity card",
+	},
+	"consentDigital.requirements.item2": {
+		es: "Correo electrónico activo",
+		en: "Active email address",
+	},
+	"consentDigital.requirements.detail2": {
+		es: "Para recibir el código de verificación OTP",
+		en: "To receive the OTP verification code",
+	},
+	"consentDigital.requirements.item3": {
+		es: "Datos de menores",
+		en: "Minors' information",
+	},
+	"consentDigital.requirements.detail3": {
+		es: "Documento y fecha de nacimiento de cada menor",
+		en: "Document and birth date of each minor",
+	},
+	"consentDigital.requirements.item4": {
+		es: "5 minutos de tu tiempo",
+		en: "5 minutes of your time",
+	},
+	"consentDigital.requirements.detail4": {
+		es: "Es todo lo que necesitas para completar el proceso",
+		en: "That's all you need to complete the process",
+	},
+
+	// --- Benefits ---
+	"consentDigital.benefits.title": {
+		es: "Por qué usar el consentimiento digital",
+		en: "Why use digital consent",
+	},
+	"consentDigital.benefits.subtitle": {
+		es: "Diseñado para familias que quieren aprovechar al máximo su tiempo en el parque.",
+		en: "Designed for families who want to make the most of their time at the park.",
+	},
+	"consentDigital.benefits.item1.title": {
+		es: "Ahorra tiempo en la entrada",
+		en: "Save time at the entrance",
+	},
+	"consentDigital.benefits.item1.description": {
+		es: "Llega al parque con el consentimiento firmado y pasa directo a la diversión. Sin filas, sin esperas, sin papeles.",
+		en: "Arrive at the park with the consent signed and go straight to the fun. No lines, no waiting, no paperwork.",
+	},
+	"consentDigital.benefits.item2.title": {
+		es: "Registra a toda tu familia",
+		en: "Register your whole family",
+	},
+	"consentDigital.benefits.item2.description": {
+		es: "Un solo adulto puede registrar a todos los menores del grupo. Cada menor queda vinculado a su responsable legal.",
+		en: "A single adult can register all minors in the group. Each minor is linked to their legal guardian.",
+	},
+	"consentDigital.benefits.item3.title": {
+		es: "Seguridad garantizada",
+		en: "Guaranteed security",
+	},
+	"consentDigital.benefits.item3.description": {
+		es: "Validación por código OTP, firma digital con valor legal, y datos protegidos. Todo cumple con la normativa colombiana.",
+		en: "OTP code validation, legally binding digital signature, and protected data. All compliant with Colombian regulations.",
+	},
+
+	// --- FAQ ---
+	"consentDigital.faq.title": {
+		es: "Preguntas frecuentes",
+		en: "Frequently asked questions",
+	},
+	"consentDigital.faq.subtitle": {
+		es: "Resuelve tus dudas antes de completar el registro.",
+		en: "Solve your questions before completing the registration.",
+	},
+	"consentDigital.faq.q1.question": {
+		es: "¿Es seguro firmar digitalmente?",
+		en: "Is it safe to sign digitally?",
+	},
+	"consentDigital.faq.q1.answer": {
+		es: "Sí. La firma digital tiene validez legal en Colombia según la Ley 527 de 1999. Tus datos están protegidos y encriptados.",
+		en: "Yes. Digital signatures have legal validity in Colombia under Law 527 of 1999. Your data is protected and encrypted.",
+	},
+	"consentDigital.faq.q2.question": {
+		es: "¿Puedo registrar a varios menores?",
+		en: "Can I register multiple minors?",
+	},
+	"consentDigital.faq.q2.answer": {
+		es: "Sí. Un adulto responsable puede registrar a todos los menores del grupo familiar. Solo necesitas los documentos de cada uno.",
+		en: "Yes. A responsible adult can register all minors in the family group. You only need each one's documents.",
+	},
+	"consentDigital.faq.q3.question": {
+		es: "¿Cuánto tiempo dura el consentimiento?",
+		en: "How long does the consent last?",
+	},
+	"consentDigital.faq.q3.answer": {
+		es: "El consentimiento es válido por el día de la visita. Debes renovarlo en cada visita al parque por seguridad.",
+		en: "The consent is valid for the day of the visit. You must renew it on each visit to the park for safety.",
+	},
+	"consentDigital.faq.q4.question": {
+		es: "¿Necesito el consentimiento si solo voy a acompañar?",
+		en: "Do I need the consent if I'm just accompanying?",
+	},
+	"consentDigital.faq.q4.answer": {
+		es: "Si no vas a usar las atracciones no necesitas firmar. Solo deben firmar quienes vayan a saltar, o el responsable de los menores.",
+		en: "If you are not going to use the attractions you do not need to sign. Only those who will jump, or the minors' guardian, must sign.",
+	},
+
+	// --- About ---
+	"consentDigital.about.title": {
+		es: "Conoce {appName}",
+		en: "Discover {appName}",
+	},
+	"consentDigital.about.description": {
+		es: "El parque de trampolines más grande de Villavicencio, ubicado en Centro Comercial Primavera Urbana. Diversión garantizada para toda la familia.",
+		en: "The largest trampoline park in Villavicencio, located in Primavera Urbana Shopping Center. Guaranteed fun for the whole family.",
+	},
+
+	// --- Contact ---
+	"consentDigital.contact.title": {
+		es: "Información de contacto",
+		en: "Contact information",
+	},
+	"consentDigital.contact.callUs": {
+		es: "Llámanos",
+		en: "Call us",
+	},
+	"consentDigital.contact.followInstagramAria": {
+		es: "Seguir en Instagram (abre en nueva pestaña)",
+		en: "Follow on Instagram (opens in new tab)",
+	},
+	"consentDigital.contact.followFacebookAria": {
+		es: "Seguir en Facebook (abre en nueva pestaña)",
+		en: "Follow on Facebook (opens in new tab)",
+	},
+
+	// --- CTA Final ---
+	"consentDigital.ctaFinal.title": {
+		es: "No pierdas más tiempo en filas",
+		en: "Don't waste more time in lines",
+	},
+	"consentDigital.ctaFinal.subtitle": {
+		es: "Completa tu consentimiento digital ahora y llega al parque listo para la diversión. Tu familia te lo agradecerá.",
+		en: "Complete your digital consent now and arrive at the park ready for fun. Your family will thank you.",
+	},
+	"consentDigital.ctaFinal.buttonPrimary": {
+		es: "Completar registro ahora",
+		en: "Complete registration now",
+	},
+	"consentDigital.ctaFinal.buttonWhatsApp": {
+		es: "Consultar por WhatsApp",
+		en: "Ask via WhatsApp",
+	},
+	"consentDigital.ctaFinal.buttonWhatsAppAria": {
+		es: "Consultar por WhatsApp (abre en nueva pestaña)",
+		en: "Ask via WhatsApp (opens in new tab)",
+	},
+	"consentDigital.ctaFinal.timeNote": {
+		es: "El proceso toma menos de 5 minutos",
+		en: "The process takes less than 5 minutes",
+	},
+
+	// --- Footer ---
+	"consentDigital.footer.logoAlt": {
+		es: "Logo de {appName}",
+		en: "{appName} Logo",
+	},
+	"consentDigital.footer.tagline": {
+		es: "El parque de trampolines más grande de Villavicencio.",
+		en: "The largest trampoline park in Villavicencio.",
+	},
+	"consentDigital.footer.quickLinks": {
+		es: "Enlaces rápidos",
+		en: "Quick links",
+	},
+	"consentDigital.footer.linkStartRegistration": {
+		es: "Iniciar registro",
+		en: "Start registration",
+	},
+	"consentDigital.footer.linkHowItWorks": {
+		es: "Cómo funciona",
+		en: "How it works",
+	},
+	"consentDigital.footer.linkFaq": {
+		es: "Preguntas frecuentes",
+		en: "Frequently asked questions",
+	},
+	"consentDigital.footer.contact": {
+		es: "Contacto",
+		en: "Contact",
+	},
+	"consentDigital.footer.followUs": {
+		es: "Síguenos",
+		en: "Follow us",
+	},
+	"consentDigital.footer.instagramAria": {
+		es: "Instagram (abre en nueva pestaña)",
+		en: "Instagram (opens in new tab)",
+	},
+	"consentDigital.footer.facebookAria": {
+		es: "Facebook (abre en nueva pestaña)",
+		en: "Facebook (opens in new tab)",
+	},
+	"consentDigital.footer.copyright": {
+		es: "&copy; {year} {appName}. Todos los derechos reservados.",
+		en: "&copy; {year} {appName}. All rights reserved.",
+	},
 } as const;
 
 export type DictionaryKey = keyof typeof dictionary;

--- a/tests/block-e-a11y-smoke.test.tsx
+++ b/tests/block-e-a11y-smoke.test.tsx
@@ -1,7 +1,14 @@
-import { describe, expect, it } from 'bun:test'
+import { describe, expect, it, mock } from 'bun:test'
 import { renderToStaticMarkup } from 'react-dom/server'
 import { Modal } from '@/components/ui/Modal'
 import { getDialogFocusLoopTarget } from '@/lib/a11y/dialog'
+
+// Mock next/headers to provide cookies() in test environment
+mock.module('next/headers', () => ({
+	cookies: async () => ({
+		get: () => undefined,
+	}),
+}))
 
 const { default: ConsentimientoDigitalPage } = await import(
 	'@/app/(public)/consentimiento-digital/page'
@@ -41,13 +48,13 @@ function collectCriticalA11ySmokeViolations(
 }
 
 describe('block e accessibility smoke coverage', () => {
-	it('keeps the public consentimiento digital page free of critical smoke violations', () => {
-		const markup = renderToStaticMarkup(<ConsentimientoDigitalPage />)
+	it('keeps the public consentimiento digital page free of critical smoke violations', async () => {
+		const markup = renderToStaticMarkup(await ConsentimientoDigitalPage())
 
 		expect(markup).toContain('<main')
 		expect(markup).toContain('<h1')
 		expect(markup).toContain('Firma tu consentimiento')
-		expect(markup).toContain('Ver como funciona')
+		expect(markup).toContain('Ver cómo funciona')
 		expect(markup).toContain('Preguntas frecuentes')
 		expect(markup).toContain('Empezar registro')
 		expect(markup).toContain('<dl')

--- a/tests/consentimiento-digital-i18n.test.ts
+++ b/tests/consentimiento-digital-i18n.test.ts
@@ -1,0 +1,312 @@
+import { describe, expect, it } from "bun:test";
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+	dictionary,
+	getTranslation,
+	type DictionaryKey,
+} from "@/lib/i18n/dictionary";
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+const PROJECT_ROOT = join(import.meta.dir, "..");
+const SRC = join(PROJECT_ROOT, "src");
+
+function readSource(relativePath: string): string {
+	return readFileSync(join(SRC, relativePath), "utf-8");
+}
+
+const PAGE_SOURCE_PATH = "app/(public)/consentimiento-digital/page.tsx";
+
+// ============================================================================
+// All consentDigital.* dictionary keys (91 keys)
+// ============================================================================
+
+const CONSENT_DIGITAL_KEYS: string[] = [
+	// tagline, country, cityRegion, mallName (4)
+	"consentDigital.tagline",
+	"consentDigital.country",
+	"consentDigital.cityRegion",
+	"consentDigital.mallName",
+
+	// stats (3)
+	"consentDigital.stats.ratingLabel",
+	"consentDigital.stats.visitorsLabel",
+	"consentDigital.stats.trampolinesLabel",
+
+	// attractions (7: title + item1-6)
+	"consentDigital.attractions.title",
+	"consentDigital.attractions.item1",
+	"consentDigital.attractions.item2",
+	"consentDigital.attractions.item3",
+	"consentDigital.attractions.item4",
+	"consentDigital.attractions.item5",
+	"consentDigital.attractions.item6",
+
+	// hours (2)
+	"consentDigital.hours.weekdays",
+	"consentDigital.hours.weekends",
+
+	// header (4)
+	"consentDigital.header.logoAlt",
+	"consentDigital.header.navProcess",
+	"consentDigital.header.navFaq",
+	"consentDigital.header.ctaButton",
+
+	// hero (10: title1, title2, subtitle, ctaPrimary, ctaSecondary, ctaWhatsApp,
+	//        ctaWhatsAppAria, imageAlt, imageCaption1, imageCaption2)
+	"consentDigital.hero.title1",
+	"consentDigital.hero.title2",
+	"consentDigital.hero.subtitle",
+	"consentDigital.hero.ctaPrimary",
+	"consentDigital.hero.ctaSecondary",
+	"consentDigital.hero.ctaWhatsApp",
+	"consentDigital.hero.ctaWhatsAppAria",
+	"consentDigital.hero.imageAlt",
+	"consentDigital.hero.imageCaption1",
+	"consentDigital.hero.imageCaption2",
+
+	// process (12: title, subtitle, step1-3.title/description/duration, requirementsTitle)
+	"consentDigital.process.title",
+	"consentDigital.process.subtitle",
+	"consentDigital.process.step1.title",
+	"consentDigital.process.step1.description",
+	"consentDigital.process.step1.duration",
+	"consentDigital.process.step2.title",
+	"consentDigital.process.step2.description",
+	"consentDigital.process.step2.duration",
+	"consentDigital.process.step3.title",
+	"consentDigital.process.step3.description",
+	"consentDigital.process.step3.duration",
+	"consentDigital.process.requirementsTitle",
+
+	// requirements (8: item1-4, detail1-4)
+	"consentDigital.requirements.item1",
+	"consentDigital.requirements.item2",
+	"consentDigital.requirements.item3",
+	"consentDigital.requirements.item4",
+	"consentDigital.requirements.detail1",
+	"consentDigital.requirements.detail2",
+	"consentDigital.requirements.detail3",
+	"consentDigital.requirements.detail4",
+
+	// benefits (8: title, subtitle, item1-3.title/description)
+	"consentDigital.benefits.title",
+	"consentDigital.benefits.subtitle",
+	"consentDigital.benefits.item1.title",
+	"consentDigital.benefits.item1.description",
+	"consentDigital.benefits.item2.title",
+	"consentDigital.benefits.item2.description",
+	"consentDigital.benefits.item3.title",
+	"consentDigital.benefits.item3.description",
+
+	// faq (10: title, subtitle, q1-4.question/answer)
+	"consentDigital.faq.title",
+	"consentDigital.faq.subtitle",
+	"consentDigital.faq.q1.question",
+	"consentDigital.faq.q1.answer",
+	"consentDigital.faq.q2.question",
+	"consentDigital.faq.q2.answer",
+	"consentDigital.faq.q3.question",
+	"consentDigital.faq.q3.answer",
+	"consentDigital.faq.q4.question",
+	"consentDigital.faq.q4.answer",
+
+	// about (2)
+	"consentDigital.about.title",
+	"consentDigital.about.description",
+
+	// contact (4)
+	"consentDigital.contact.title",
+	"consentDigital.contact.callUs",
+	"consentDigital.contact.followInstagramAria",
+	"consentDigital.contact.followFacebookAria",
+
+	// ctaFinal (6)
+	"consentDigital.ctaFinal.title",
+	"consentDigital.ctaFinal.subtitle",
+	"consentDigital.ctaFinal.buttonPrimary",
+	"consentDigital.ctaFinal.buttonWhatsApp",
+	"consentDigital.ctaFinal.buttonWhatsAppAria",
+	"consentDigital.ctaFinal.timeNote",
+
+	// footer (11)
+	"consentDigital.footer.logoAlt",
+	"consentDigital.footer.tagline",
+	"consentDigital.footer.quickLinks",
+	"consentDigital.footer.linkStartRegistration",
+	"consentDigital.footer.linkHowItWorks",
+	"consentDigital.footer.linkFaq",
+	"consentDigital.footer.contact",
+	"consentDigital.footer.followUs",
+	"consentDigital.footer.instagramAria",
+	"consentDigital.footer.facebookAria",
+	"consentDigital.footer.copyright",
+];
+
+// ============================================================================
+// CYCLE 1 — Dictionary Keys
+// ============================================================================
+
+describe("CYCLE 1 — consentDigital dictionary keys exist", () => {
+	for (const keyName of CONSENT_DIGITAL_KEYS) {
+		it(`[RED 1a] key "${keyName}" exists in dictionary`, () => {
+			expect(keyName in dictionary).toBe(true);
+		});
+	}
+
+	for (const keyName of CONSENT_DIGITAL_KEYS) {
+		it(`[RED 1b] key "${keyName}" has non-empty Spanish translation`, () => {
+			const result = getTranslation(keyName as DictionaryKey, "es");
+			expect(result).toBeString();
+			expect(result.length).toBeGreaterThan(0);
+			expect(result).not.toBe(keyName);
+		});
+	}
+
+	for (const keyName of CONSENT_DIGITAL_KEYS) {
+		it(`[RED 1c] key "${keyName}" has non-empty English translation`, () => {
+			const result = getTranslation(keyName as DictionaryKey, "en");
+			expect(result).toBeString();
+			expect(result.length).toBeGreaterThan(0);
+			expect(result).not.toBe(keyName);
+		});
+	}
+});
+
+// ============================================================================
+// CYCLE 1 — Specific content assertions (spot checks)
+// ============================================================================
+
+describe("CYCLE 1 — consentDigital dictionary content spot checks", () => {
+	it("[RED 1d] consentDigital.hero.title1 is 'Firma tu consentimiento' in es", () => {
+		expect(
+			getTranslation("consentDigital.hero.title1" as DictionaryKey, "es"),
+		).toBe("Firma tu consentimiento");
+	});
+
+	it("[RED 1e] consentDigital.hero.title1 is 'Sign your consent' in en", () => {
+		expect(
+			getTranslation("consentDigital.hero.title1" as DictionaryKey, "en"),
+		).toBe("Sign your consent");
+	});
+
+	it("[RED 1f] consentDigital.hero.title2 is 'antes de llegar' in es", () => {
+		expect(
+			getTranslation("consentDigital.hero.title2" as DictionaryKey, "es"),
+		).toBe("antes de llegar");
+	});
+
+	it("[RED 1g] consentDigital.hero.title2 is 'before arriving' in en", () => {
+		expect(
+			getTranslation("consentDigital.hero.title2" as DictionaryKey, "en"),
+		).toBe("before arriving");
+	});
+
+	it("[RED 1h] consentDigital.header.ctaButton is 'Iniciar registro' in es", () => {
+		expect(
+			getTranslation("consentDigital.header.ctaButton" as DictionaryKey, "es"),
+		).toBe("Iniciar registro");
+	});
+
+	it("[RED 1i] consentDigital.header.ctaButton is 'Start registration' in en", () => {
+		expect(
+			getTranslation("consentDigital.header.ctaButton" as DictionaryKey, "en"),
+		).toBe("Start registration");
+	});
+
+	it("[RED 1j] consentDigital.footer.copyright contains {appName} template", () => {
+		const esResult = getTranslation(
+			"consentDigital.footer.copyright" as DictionaryKey,
+			"es",
+		);
+		expect(esResult).toContain("{appName}");
+	});
+});
+
+// ============================================================================
+// CYCLE 2 — Page uses createServerTranslator (RED phase)
+// ============================================================================
+
+describe("CYCLE 2 — page.tsx uses createServerTranslator", () => {
+	it("[RED 2a] page.tsx imports createServerTranslator", () => {
+		const source = readSource(PAGE_SOURCE_PATH);
+		expect(source).toContain("createServerTranslator");
+	});
+
+	it("[RED 2b] page.tsx is an async function (Server Component)", () => {
+		const source = readSource(PAGE_SOURCE_PATH);
+		expect(source).toMatch(/async\s+function\s+ConsentimientoDigitalPage/);
+	});
+
+	it("[RED 2c] page.tsx does NOT use 'use client'", () => {
+		const source = readSource(PAGE_SOURCE_PATH);
+		expect(source).not.toContain('"use client"');
+	});
+
+	it("[RED 2d] page.tsx imports LanguageProvider", () => {
+		const source = readSource(PAGE_SOURCE_PATH);
+		expect(source).toContain("LanguageProvider");
+	});
+
+	it("[RED 2e] page.tsx wraps content in LanguageProvider with initialLanguage", () => {
+		const source = readSource(PAGE_SOURCE_PATH);
+		expect(source).toContain("LanguageProvider");
+		expect(source).toContain("initialLanguage");
+	});
+
+	it("[RED 2f] page.tsx uses t() for consentDigital keys (no hardcoded 'Firma tu consentimiento')", () => {
+		const source = readSource(PAGE_SOURCE_PATH);
+		// The hardcoded H1 string should not appear as a raw string literal
+		expect(source).not.toContain('"Firma tu consentimiento"');
+		expect(source).not.toContain("'Firma tu consentimiento'");
+	});
+
+	it("[RED 2g] page.tsx uses t() for consentDigital keys (no hardcoded 'Como funciona')", () => {
+		const source = readSource(PAGE_SOURCE_PATH);
+		expect(source).not.toContain('"Como funciona"');
+		expect(source).not.toContain("'Como funciona'");
+	});
+
+	it("[RED 2h] page.tsx uses t() for consentDigital keys (no hardcoded 'Preguntas')", () => {
+		const source = readSource(PAGE_SOURCE_PATH);
+		expect(source).not.toContain('"Preguntas"');
+		expect(source).not.toContain("'Preguntas'");
+	});
+
+	it("[RED 2i] page.tsx uses consentDigital dictionary key references", () => {
+		const source = readSource(PAGE_SOURCE_PATH);
+		expect(source).toContain("consentDigital.hero.title1");
+		expect(source).toContain("consentDigital.header.ctaButton");
+	});
+});
+
+// ============================================================================
+// CYCLE 3 — LanguageToggle in header (RED phase)
+// ============================================================================
+
+describe("CYCLE 3 — LanguageToggle in header", () => {
+	it("[RED 3a] page.tsx imports LanguageToggle", () => {
+		const source = readSource(PAGE_SOURCE_PATH);
+		expect(source).toContain("LanguageToggle");
+	});
+
+	it("[RED 3b] page.tsx renders LanguageToggle in the header nav", () => {
+		const source = readSource(PAGE_SOURCE_PATH);
+		// LanguageToggle should appear inside the header component
+		expect(source).toContain("LanguageToggle");
+	});
+
+	it("[RED 3c] JSON-LD structured data is still present", () => {
+		const source = readSource(PAGE_SOURCE_PATH);
+		expect(source).toContain("application/ld+json");
+		expect(source).toContain("buildPublicPageStructuredData");
+	});
+
+	it("[RED 3d] metadata export is still present", () => {
+		const source = readSource(PAGE_SOURCE_PATH);
+		expect(source).toContain("export const metadata");
+	});
+});

--- a/tests/consentimiento-digital-trust-slice.test.tsx
+++ b/tests/consentimiento-digital-trust-slice.test.tsx
@@ -1,6 +1,13 @@
-import { describe, expect, it } from 'bun:test'
+import { describe, expect, it, mock } from 'bun:test'
 import type { ReactNode } from 'react'
 import { renderToStaticMarkup } from 'react-dom/server'
+
+// Mock next/headers to provide cookies() in test environment
+mock.module('next/headers', () => ({
+	cookies: async () => ({
+		get: () => undefined, // default to 'es'
+	}),
+}))
 
 const { default: ConsentimientoDigitalPage } = await import(
 	'@/app/(public)/consentimiento-digital/page'
@@ -104,22 +111,19 @@ function isFaqPageSchema(value: unknown): value is {
 }
 
 describe('consentimiento digital trust slice', () => {
-	it('renders the trust narrative, faq content, and CTA in SSR markup', () => {
-		const markup = renderToStaticMarkup(<ConsentimientoDigitalPage />)
+	it('renders the trust narrative, faq content, and CTA in SSR markup', async () => {
+		const markup = renderToStaticMarkup(await ConsentimientoDigitalPage())
 
-		expect(markup).toContain(
-			'Firma tu consentimiento',
-		)
+		// Page uses t() with Spanish locale — verify Spanish strings present
+		expect(markup).toContain('Firma tu consentimiento')
 		expect(markup).toContain('Preguntas frecuentes')
-		expect(markup).toContain(
-			'Completar registro ahora',
-		)
-		expect(markup).toContain('No pierdas mas tiempo en filas')
+		expect(markup).toContain('Completar registro ahora')
+		expect(markup).toContain('No pierdas más tiempo en filas')
 	})
 
-	it('keeps the FAQ entries visible in markup and faq json-ld output', () => {
-		const pageTree = ConsentimientoDigitalPage()
-		const markup = renderToStaticMarkup(<ConsentimientoDigitalPage />)
+	it('keeps the FAQ entries visible in markup and faq json-ld output', async () => {
+		const pageTree = await ConsentimientoDigitalPage()
+		const markup = renderToStaticMarkup(pageTree)
 		const firstEntry = CONSENTIMIENTO_DIGITAL_FAQ_ENTRIES[0]
 		const lastEntry = CONSENTIMIENTO_DIGITAL_FAQ_ENTRIES.at(-1)
 		const elementIds = findElementIds(pageTree)

--- a/tests/global-viewport-consentimiento-a11y.test.tsx
+++ b/tests/global-viewport-consentimiento-a11y.test.tsx
@@ -16,6 +16,15 @@ mock.module("next/font/google", () => ({
 }));
 
 // ---------------------------------------------------------------------------
+// Mock next/headers to provide cookies() in test environment
+// ---------------------------------------------------------------------------
+mock.module("next/headers", () => ({
+	cookies: async () => ({
+		get: () => undefined,
+	}),
+}));
+
+// ---------------------------------------------------------------------------
 // TASK 1: Root viewport MUST allow user scaling
 // ---------------------------------------------------------------------------
 
@@ -91,7 +100,7 @@ describe("consentimiento-digital main-content anchor", () => {
 		const { default: ConsentimientoDigitalPage } = await import(
 			"@/app/(public)/consentimiento-digital/page"
 		);
-		const markup = renderToStaticMarkup(<ConsentimientoDigitalPage />);
+		const markup = renderToStaticMarkup(await ConsentimientoDigitalPage());
 		expect(markup).toContain('<main');
 		expect(markup).toContain('id="main-content"');
 	});
@@ -124,7 +133,7 @@ describe("consentimiento-digital external link accessible names", () => {
 		const { default: ConsentimientoDigitalPage } = await import(
 			"@/app/(public)/consentimiento-digital/page"
 		);
-		const markup = renderToStaticMarkup(<ConsentimientoDigitalPage />);
+		const markup = renderToStaticMarkup(await ConsentimientoDigitalPage());
 
 		// Count target="_blank" occurrences
 		const blankCount = (markup.match(/target="_blank"/g) ?? []).length;
@@ -141,7 +150,7 @@ describe("consentimiento-digital external link accessible names", () => {
 		const { default: ConsentimientoDigitalPage } = await import(
 			"@/app/(public)/consentimiento-digital/page"
 		);
-		const markup = renderToStaticMarkup(<ConsentimientoDigitalPage />);
+		const markup = renderToStaticMarkup(await ConsentimientoDigitalPage());
 
 		// There should be at least one WhatsApp link with target=_blank that announces new tab
 		expect(markup).toContain("wa.me");

--- a/tests/images.test.tsx
+++ b/tests/images.test.tsx
@@ -1,7 +1,14 @@
 import { existsSync, readFileSync, statSync } from 'node:fs'
 import { join } from 'node:path'
-import { describe, expect, it } from 'bun:test'
+import { describe, expect, it, mock } from 'bun:test'
 import { renderToStaticMarkup } from 'react-dom/server'
+
+// Mock next/headers to provide cookies() in test environment
+mock.module('next/headers', () => ({
+	cookies: async () => ({
+		get: () => undefined,
+	}),
+}))
 
 const { default: ConsentimientoDigitalPage } = await import(
 	'@/app/(public)/consentimiento-digital/page',
@@ -75,8 +82,8 @@ describe('image optimization phase', () => {
 		)
 	})
 
-	it('renders responsive next/image markup for the consentimiento digital public page', () => {
-		const markup = renderToStaticMarkup(<ConsentimientoDigitalPage />)
+	it('renders responsive next/image markup for the consentimiento digital public page', async () => {
+		const markup = renderToStaticMarkup(await ConsentimientoDigitalPage())
 
 		expect(markup).toContain('jumping-park-logo.webp')
 		expect(markup).toContain(


### PR DESCRIPTION
## Consentimiento-digital i18n

### Changes
- Add 91 dictionary keys (consentDigital.*) for both es/en locales
- Rewrite page as async Server Component with createServerTranslator()
- Add LanguageProvider and LanguageToggle to page header
- All hardcoded Spanish replaced with t() calls
- JSON-LD structured data preserved (not translated)
- Phone number with WhatsApp link and green styling
- LanguageToggle visibility fix (overflow-hidden -> overflow-x-hidden)

### Testing
- 293 new TDD tests for dictionary keys and page i18n
- 946/946 total tests passing
- Code review PASSED

### Files
- src/app/(public)/consentimiento-digital/page.tsx (rewritten)
- src/lib/i18n/dictionary.ts (91 new keys)
- tests/consentimiento-digital-i18n.test.ts (created)
- 4 test files updated for async page compatibility