### PR TITLE
fix(ui): restore homepage visual order — CTA after hero text

### DIFF
--- a/src/app/(public)/opengraph-image.tsx
+++ b/src/app/(public)/opengraph-image.tsx
@@ -112,7 +112,7 @@ export default function OpenGraphImage() {
 						gap: "24px",
 					}}
 				>
-						<img
+					<img
 						src={logoSrc}
 						alt={`${APP_NAME} logo`}
 						width={120}

--- a/src/components/kiosk/HomepageHeroIsland.tsx
+++ b/src/components/kiosk/HomepageHeroIsland.tsx
@@ -2,7 +2,6 @@
 
 import dynamic from "next/dynamic";
 import Image from "next/image";
-import { StartActionButton } from "@/components/kiosk/StartActionButton";
 import { PAGE_IMAGE_VARIANTS } from "@/lib/imageOptimization";
 
 const SpaceBackground = dynamic(
@@ -12,10 +11,6 @@ const SpaceBackground = dynamic(
 );
 
 interface HomepageHeroIslandProps {
-	/** Translated CTA button text */
-	ctaText: string;
-	/** Translated CTA button aria-label */
-	ctaAriaLabel: string;
 	/** Translated astronaut alt text */
 	astronautAlt: string;
 	/** Translated solar system alt text */
@@ -23,16 +18,12 @@ interface HomepageHeroIslandProps {
 }
 
 /**
- * HomepageHeroIsland — Client-side island containing all interactive
- * and animated hero elements (canvas background, images, CTA button,
- * secret admin trigger).
+ * HomepageHeroIsland — Client-side island containing decorative
+ * and animated hero elements (canvas background, astronaut, solar system).
  *
- * Receives ALL translated strings as props — never reads from context.
- * This keeps the island decoupled from i18n and render-android outside SSR.
+ * Interactive elements (CTA, bounce) are in HomepageShell for correct DOM order.
  */
 export function HomepageHeroIsland({
-	ctaText,
-	ctaAriaLabel,
 	astronautAlt,
 	solarSystemAlt,
 }: HomepageHeroIslandProps) {
@@ -85,19 +76,6 @@ export function HomepageHeroIsland({
 							/>
 						</div>
 						<div className="absolute inset-0 bg-linear-to-l from-transparent via-[#111C59]/20 to-transparent blur-2xl" />
-					</div>
-				</div>
-
-				{/* Logo is rendered in HomepageShell (server component) for LCP */}
-
-				{/* CTA */}
-				<div className="w-full max-w-2xl transform transition-transform duration-300 hover:scale-[1.02]">
-					<StartActionButton ctaText={ctaText} ctaAriaLabel={ctaAriaLabel} />
-				</div>
-
-				<div className="mt-16 animate-bounce">
-					<div className="mx-auto h-14 w-8 rounded-full border-2 border-white/30 p-1">
-						<div className="h-3 w-full animate-pulse rounded-full bg-white/60" />
 					</div>
 				</div>
 			</section>

--- a/src/components/kiosk/HomepageShell.tsx
+++ b/src/components/kiosk/HomepageShell.tsx
@@ -3,6 +3,7 @@ import Image from "next/image";
 import Link from "next/link";
 import { HomepageHeroIsland } from "@/components/kiosk/HomepageHeroIsland";
 import { LanguageToggle } from "@/components/kiosk/LanguageToggle";
+import { StartActionButton } from "@/components/kiosk/StartActionButton";
 import { SecretAdminTrigger } from "@/components/ui/SecretAdminTrigger";
 import type { DictionaryKey, Language } from "@/lib/i18n/dictionary";
 import { PAGE_IMAGE_VARIANTS } from "@/lib/imageOptimization";
@@ -38,10 +39,8 @@ export function HomepageShell({ t, locale: _locale }: HomepageShellProps) {
 			id="main-content"
 			className="relative min-h-screen w-full overflow-x-hidden bg-background text-foreground"
 		>
-			{/* Client island — SpaceBackground, images, CTA, bounce indicator */}
+			{/* Client island — SpaceBackground, astronaut, solar-system */}
 			<HomepageHeroIsland
-				ctaText={ctaText}
-				ctaAriaLabel={ctaAriaLabel}
 				astronautAlt={astronautAlt}
 				solarSystemAlt={solarSystemAlt}
 			/>
@@ -81,6 +80,18 @@ export function HomepageShell({ t, locale: _locale }: HomepageShellProps) {
 					<p className="mb-12 max-w-xl text-xl font-light tracking-wide text-white/80 sm:text-2xl md:text-3xl">
 						{t("home.subtitle")}
 					</p>
+
+					{/* CTA — client interactive button */}
+					<div className="w-full max-w-2xl transform transition-transform duration-300 hover:scale-[1.02]">
+						<StartActionButton ctaText={ctaText} ctaAriaLabel={ctaAriaLabel} />
+					</div>
+
+					{/* Bounce indicator */}
+					<div className="mt-16 animate-bounce">
+						<div className="mx-auto h-14 w-8 rounded-full border-2 border-white/30 p-1">
+							<div className="h-3 w-full animate-pulse rounded-full bg-white/60" />
+						</div>
+					</div>
 				</section>
 
 				{/* ATRACCIONES */}

--- a/tests/homepage-ssr-phase2.test.ts
+++ b/tests/homepage-ssr-phase2.test.ts
@@ -106,8 +106,8 @@ describe("Task 2.1 — HomepageHeroIsland client island", () => {
 		expect(source).toContain("SpaceBackground");
 	});
 
-	it("[TRIANGULATE 2.1f] HomepageHeroIsland imports StartActionButton", () => {
-		const source = readFileSync(HERO_ISLAND_PATH, "utf-8");
+	it("[TRIANGULATE 2.1f] HomepageShell imports StartActionButton for CTA", () => {
+		const source = readFileSync(SHELL_PATH, "utf-8");
 		expect(source).toContain("StartActionButton");
 	});
 });


### PR DESCRIPTION
## Fix homepage layout order

The SSR refactor broke the visual order by placing CTA button and bounce indicator before the logo/H1.

### Fix
- Move CTA + bounce from HomepageHeroIsland to HomepageShell
- HomepageHeroIsland now only contains decorative elements (SpaceBackground, astronaut, solar-system)
- Visual order restored: Logo → H1 → Subtitle → CTA → Bounce

### Testing
- 946/946 tests passing
- Code review PASSED