### PR TITLE
fix(ui): move H1 and subtitle above CTA button

### DIFF
--- a/src/components/kiosk/HomepageContent.tsx
+++ b/src/components/kiosk/HomepageContent.tsx
@@ -20,20 +20,6 @@ export function HomepageContent() {
 
 	return (
 		<>
-			{/* HERO TEXT */}
-			<section className="flex flex-1 flex-col items-center justify-center px-6 text-center">
-				<h1 className="font-sora mb-6 text-6xl font-black uppercase leading-none tracking-tight text-white drop-shadow-2xl sm:text-7xl md:text-8xl lg:text-9xl">
-					{t("home.title.line1")}
-					<span className="mt-2 block bg-linear-to-r from-primary via-yellow-300 to-primary bg-clip-text text-transparent">
-						{t("home.title.line2")}
-					</span>
-				</h1>
-
-				<p className="mb-12 max-w-xl text-xl font-light tracking-wide text-white/80 sm:text-2xl md:text-3xl">
-					{t("home.subtitle")}
-				</p>
-			</section>
-
 			{/* ATRACCIONES */}
 			<section className="px-6 py-12">
 				<div className="mx-auto max-w-4xl">

--- a/src/components/kiosk/HomepageShell.tsx
+++ b/src/components/kiosk/HomepageShell.tsx
@@ -50,7 +50,7 @@ export function HomepageShell({ t }: HomepageShellProps) {
 					<LanguageToggle variant="premium" />
 				</div>
 
-				{/* Logo + CTA + Bounce — fixed position, not affected by language toggle */}
+				{/* Hero section — Logo, H1, CTA, Bounce */}
 				<section className="flex flex-1 flex-col items-center justify-center px-6 text-center">
 					{/* Logo with 5-click admin trigger */}
 					<div className="mb-8 animate-fade-in">
@@ -66,6 +66,18 @@ export function HomepageShell({ t }: HomepageShellProps) {
 							/>
 						</SecretAdminTrigger>
 					</div>
+
+					{/* H1 + Subtitle */}
+					<h1 className="font-sora mb-6 text-6xl font-black uppercase leading-none tracking-tight text-white drop-shadow-2xl sm:text-7xl md:text-8xl lg:text-9xl">
+						{t("home.title.line1")}
+						<span className="mt-2 block bg-linear-to-r from-primary via-yellow-300 to-primary bg-clip-text text-transparent">
+							{t("home.title.line2")}
+						</span>
+					</h1>
+
+					<p className="mb-12 max-w-xl text-xl font-light tracking-wide text-white/80 sm:text-2xl md:text-3xl">
+						{t("home.subtitle")}
+					</p>
 
 					{/* CTA — client interactive button */}
 					<div className="w-full max-w-2xl transform transition-transform duration-300 hover:scale-[1.02]">

--- a/tests/homepage-ssr-phase2.test.ts
+++ b/tests/homepage-ssr-phase2.test.ts
@@ -129,8 +129,8 @@ describe("Task 2.2 — HomepageShell Server Component", () => {
 		expect(source).not.toContain('"use client"');
 	});
 
-	it("[RED 2.2c] HomepageContent renders H1 with home.title.line1 and line2 keys", () => {
-		const source = readFileSync(CONTENT_PATH, "utf-8");
+	it("[RED 2.2c] HomepageShell renders H1 with home.title.line1 and line2 keys", () => {
+		const source = readFileSync(SHELL_PATH, "utf-8");
 		expect(source).toContain("home.title.line1");
 		expect(source).toContain("home.title.line2");
 	});


### PR DESCRIPTION
Restore correct visual order on homepage:
1. Logo
2. H1 + subtitle
3. CTA button
4. Bounce indicator

948/948 tests passing. Code review PASSED.